### PR TITLE
BBL airborne restructuring

### DIFF
--- a/trackingC.Rmd
+++ b/trackingC.Rmd
@@ -64,12 +64,12 @@ formula above produces negative numbers if $\Delta$ATM < 0.
 
 ## Setup
 
-1. Create random parameter draw from a priori PDFs from literature (note that 
+1. Create random parameter draws from a priori PDFs from literature (note that 
 we have not yet implemented joint PDFs).
 2. Parameterize Hector.
 3. Run Hector 1000 times (note that we are working on parallelizing this script
 to be run on pic, and the number of runs will scale up - at least 100,000?)
-4. Extracte standard output (pools and fluxes) and carbon tracking data. 
+4. Extract standard output (pools and fluxes) and carbon tracking data. 
 5. Visualize data in four parts: sanity checks, graphs focusing on ƒATM~ffi~,
 graphs focusing on ƒFFI~atm~, and graphs of airborne fraction.
 

--- a/trackingC.Rmd
+++ b/trackingC.Rmd
@@ -529,7 +529,9 @@ emissions <- trk_output %>%
          source_name == "earth_c",
          run_number == min(run_number)) %>%
   arrange(year) %>%
-  mutate(emissions = -c(0, diff(pool_value)),
+  # the NA at the end here is so that cumulative emissions 'line up' correctly
+  # with the source_quantity (earth-origin atmosphere C) calculated below
+  mutate(emissions = -c(diff(pool_value), NA),
          # relative to 2000
          cumulative_emissions = cumsum(emissions)) %>%
   select(year, cumulative_emissions)

--- a/trackingC.Rmd
+++ b/trackingC.Rmd
@@ -40,6 +40,13 @@ Basically the introductory sentences from existing google doc:
 * ƒFFI~atm~: the fraction of fossil fuel emissions residing in the atmosphere
 * AF: airborne fraction, conventionally computed as $\Delta$ATM / $\Sigma$FFI over some time period
 
+Note that AF is commonly described as "the fraction of anthropogenic emissions 
+which remain in the atmosphere" 
+([source](https://gml.noaa.gov/co2conference/posters_pdf/jones1_poster.pdf)), 
+the ratio above will not exactly be that, because in some circumstances earth 
+system feedbacks will add to atmospheric C as well. In addition, the 
+formula above produces negative numbers if $\Delta$ATM < 0.
+
 Could also use "A" (atmosphere) and "E" (emissions) above, if clearer?
 
 ## Setup
@@ -69,7 +76,7 @@ ssp245 <- system.file("input/hector_ssp245.ini", package = "hector")
 core <- newcore(ssp245)
 
 # Set range of years for output data
-years <- 2000:2200
+OUTPUT_YEARS <- 2000:2200
 
 # Set random number generator to allow for reproducibility 
 set.seed(10)
@@ -84,7 +91,7 @@ set.seed(10)
 # Reference: https://msalganik.wordpress.com/2017/01/21/making-sense-of-the-rlnorm-function-in-r/
 lognorm <- function(m, sd){
   location <- log(m^2 / sqrt(sd^2 + m^2))
-  shape <- sqrt(log(1+ (sd^2 / m^2)))
+  shape <- sqrt(log(1 + (sd^2 / m^2)))
   v <- c(location, shape)
 }
 
@@ -143,8 +150,8 @@ run_hector <- function(pdata, c) {
   run(c)
   # Access and save tracking data, model outputs
   out <- list()
-  out$tdata <- get_tracking_data(c) %>% filter(year %in% years)
-  out$results <- fetchvars(c, years)
+  out$tdata <- get_tracking_data(c) %>% filter(year %in% OUTPUT_YEARS)
+  out$results <- fetchvars(c, OUTPUT_YEARS)
   return(out)
 }
 

--- a/trackingC.Rmd
+++ b/trackingC.Rmd
@@ -13,7 +13,7 @@ output:
 ---
 
 ```{r setup, include=FALSE}
-knitr::opts_chunk$set(echo = TRUE)
+knitr::opts_chunk$set(echo = TRUE, warning = FALSE)
 ```
 
 # Introduction
@@ -103,6 +103,10 @@ set.seed(10)
 
 ### Create runlist of parameter draws
 
+Currently, we are looking at six Hector parameters: `BETA(), Q10_RH(), ECS(),
+NPP_FLUX0(), AERO_SCALE(), DIFFUSIVITY()`. We created a runlist with 1000 random
+draws in a normal (or lognormal, where applicable) distribution.
+
 ```{r params}
 # Create runlist of parameters of interest
 
@@ -152,6 +156,7 @@ units_vector <- c("BETA" = "(unitless)", "Q10_RH" = "(unitless)",
 ```
 
 ## Run the model
+Run the model and store outputs and tracking data.
 
 ```{r functions, cache=TRUE, message=FALSE}
 run_hector <- function(pdata, c) {
@@ -204,6 +209,7 @@ tm <- difftime(Sys.time(), start, units = "secs") %>% round(1)
 Doing `r N_RUNS` runs took `r tm` seconds or `r tm/N_RUNS` s/job.
 
 ## Process data
+Get lists from above into nice dataframes.
 
 ``` {r data}
 # Get output data frames
@@ -550,9 +556,9 @@ plot_data <- bind_rows(emissions_fraction, classic_af) %>%
 
 ggplot(plot_data, aes(x = year, group = paste0(def, run_number), fill = def)) +
   geom_ribbon(aes(ymin = minimum, ymax = maximum), 
-              alpha = 0.05) +
+              alpha = 0.15) +
   geom_ribbon(aes(ymin = med - sdev, ymax = med + sdev), 
-              alpha = 0.10) +
+              alpha = 0.3) +
   geom_line(aes(y = med, color = def)) +
   scale_color_viridis_d(begin = 0.5) +
   scale_fill_viridis_d(begin = 0.5) +

--- a/trackingC.Rmd
+++ b/trackingC.Rmd
@@ -450,7 +450,7 @@ ggplot(relimp_out, aes(year, value, fill = param)) +
   coord_cartesian(expand = FALSE) +
   scale_fill_viridis_d(direction = -1) +
   labs(x = "Year",
-       y = expression(Relative~importance~"for"~ƒFFI[atm]))
+       y = expression(Relative~importance~"for"~FFI[atm]))
 ```
 
 ## Airborne fraction

--- a/trackingC.Rmd
+++ b/trackingC.Rmd
@@ -40,8 +40,8 @@ Basically the introductory sentences from existing google doc:
 * ƒFFI~atm~: the fraction of fossil fuel emissions residing in the atmosphere
 * AF: airborne fraction, conventionally computed as $\Delta$ATM / $\Sigma$FFI over some time period
 
-Note that AF is commonly described as "the fraction of anthropogenic emissions 
-which remain in the atmosphere" 
+Note that while AF is commonly described as "the fraction of anthropogenic 
+emissions which remain in the atmosphere" 
 ([source](https://gml.noaa.gov/co2conference/posters_pdf/jones1_poster.pdf)), 
 the ratio above will not exactly be that, because in some circumstances earth 
 system feedbacks will add to atmospheric C as well. In addition, the 
@@ -51,7 +51,7 @@ Could also use "A" (atmosphere) and "E" (emissions) above, if clearer?
 
 ## Setup
 
-We <describe methodology in a few bullets>: random parameter draws from
+We (describe methodology in a few bullets): random parameter draws from
 a priori PDFs from literature; parameterized Hector; ran XXX times; using
 both standard outputs (pools and fluxes) and carbon-tracking data.
 

--- a/trackingC.Rmd
+++ b/trackingC.Rmd
@@ -426,9 +426,14 @@ calc_relimp <- function(x) {
   # Calculate relative importance metrics and extract 'lmg' results
   # 'lmg' is the R^2 contribution averaged over orderings among regressors;
   # should sum to one because we're using relative importances (rela=TRUE)
-  relimp <- calc.relimp(m, type = "lmg", rela = TRUE)@lmg
+  relimp <- try(calc.relimp(m, type = "lmg", rela = TRUE)@lmg)
+  if(class(relimp) == "try-error") {
+    message(yr, " calc.relimp error")
+    return(NULL)
+  }
   # Return a data frame: year, parameter, relative importance
   tibble(year = yr, param = names(relimp), value = relimp)
+  
 }
 
 # Run calc_relimp above on each year's data

--- a/trackingC.Rmd
+++ b/trackingC.Rmd
@@ -9,14 +9,18 @@ output:
     toc: true
     toc_depth: 2
     toc_float: true
-    code_folding: show
+    code_folding: hide
 ---
 
 ```{r setup, include=FALSE}
 knitr::opts_chunk$set(echo = TRUE)
 ```
 
-# Setup
+# Introduction
+
+# Methods
+
+## Setup
 
 Load necessary packages, read in an ini file and initiate core, and set seed for reproducibility.
 
@@ -44,7 +48,7 @@ set.seed(10)
 
 ```
 
-# Create dataset
+## Create dataset
 
 ```{r params}
 # Create runlist of parameters of interest
@@ -94,7 +98,7 @@ units_vector <- c("BETA" = "(unitless)", "Q10_RH" = "(unitless)",
                   )
 ```
 
-# Run the model
+## Run the model
 
 ```{r functions, cache=TRUE, message=FALSE}
 run_hector <- function(pdata, c) {
@@ -144,9 +148,9 @@ for(row in seq_len(nrow(runlist))) {
 tm <- difftime(Sys.time(), start, units = "secs") %>% round(1)
 ```
 
-Running took `r tm` seconds or `r tm/N_RUNS` s/job.
+Doing `r N_RUNS` runs took `r tm` seconds or `r tm/N_RUNS` s/job.
 
-# Process data
+## Process data
 
 ``` {r data}
 # Get output data frames
@@ -185,9 +189,9 @@ results_slice <- filter(results, run_number %in% max_display$run_number)
 The following sections contain tentative figures in the order they would appear
 in a manuscript. 
 
-# Parameters and PDFS
+# Realized parameter PDFs
 
-``` {r params-PDFs, fig.cap = " Probability densities of each parameter"}
+``` {r params-PDFs, fig.cap = paste0(" Probability densities of each parameter (N=", N_RUNS, " draws).")}
 # Density plot to visualize parameter distributions
 runlist %>% 
   select(-run_number) %>%
@@ -195,8 +199,46 @@ runlist %>%
   ggplot(aes(value)) +
   geom_density() + 
   facet_wrap(~name, scales = "free") +
-  labs(x = NULL, 
-       y = NULL)
+  labs(x = NULL, y = NULL)
+```
+
+# Hector temperature vs. CMIP6 
+
+``` {r cmip, fig.cap = " Global temperature anomaly outputs from CMIP6 and Hector runs."}
+# Read in comparison data
+cmip <- read.csv("CMIP6_annual_tas_global.csv") %>%
+  filter(variable == "Tgav",
+         experiment == "ssp245") %>%
+  group_by(year) %>%
+  summarize(sdev = sd(value),
+            minimum = min(value),
+            maximum = max(value),
+            med = median(value)) %>%
+  mutate(source = "CMIP6")
+
+# Extract Hector data
+hector <- results %>%
+  filter(variable == "Tgav",
+         year >= 2015 & year <= 2100) %>%
+  group_by(year) %>%
+  summarize(sdev = sd(value),
+            minimum = min(value),
+            maximum = max(value),
+            med = median(value)) %>%
+  mutate(source = "Hector")
+
+# Combine data
+temp <- bind_rows(cmip, hector)
+
+# Plot temperature spread
+ggplot(temp, aes(year, fill = source, color = source)) +
+  geom_ribbon(aes(ymin = minimum, ymax = maximum), alpha = 0.15) +
+  geom_ribbon(aes(ymin = med - sdev, ymax = med + sdev), alpha = 0.5) +
+  geom_line(aes(y = med)) +
+  scale_color_viridis_d(begin = 0.5) +
+  scale_fill_viridis_d(begin = 0.5) +
+  labs(x = "Year",
+       y = expression(degree*C))
 ```
 
 # Hector output graphs
@@ -353,46 +395,6 @@ ggplot(relimp_out, aes(year, value, fill = param)) +
   scale_fill_viridis_d(direction = -1) +
   labs(x = "Year",
        y = "Fraction of relative importance")
-```
-
-# Comparing Hector temperature data to CMIP6 
-
-``` {r cmip, fig.cap = " Global temperature anomaly data from CMIP6 and Hector runs"}
-# Read in comparison data
-cmip <- read.csv("CMIP6_annual_tas_global.csv") %>%
-  filter(variable == "Tgav",
-         experiment == "ssp245") %>%
-  group_by(year) %>%
-  summarize(sdev = sd(value),
-            minimum = min(value),
-            maximum = max(value),
-            med = median(value)) %>%
-  mutate(source = "CMIP6")
-
-# Extract Hector data
-hector <- results %>%
-  filter(variable == "Tgav",
-         year >= 2015 & year <= 2100) %>%
-  group_by(year) %>%
-  summarize(sdev = sd(value),
-            minimum = min(value),
-            maximum = max(value),
-            med = median(value)) %>%
-  mutate(source = "Hector")
-
-# Combine data
-temp <- bind_rows(cmip, hector)
-
-# Plot temperature spread
-ggplot(temp, aes(year, fill = source, color = source)) +
-  geom_ribbon(aes(ymin = minimum, ymax = maximum), alpha = 0.15) +
-  geom_ribbon(aes(ymin = med - sdev, ymax = med + sdev), alpha = 0.5) +
-  geom_line(aes(y = med)) +
-  scale_color_viridis_d(begin = 0.5) +
-  scale_fill_viridis_d(begin = 0.5) +
-  labs(x = "Year",
-       y = "deg C")
-
 ```
 
 # BBL AF

--- a/trackingC.Rmd
+++ b/trackingC.Rmd
@@ -185,7 +185,6 @@ results <- left_join(results, runlist, by = "run_number")
 max_display <- slice_sample(runlist, n = 100)
 output_slice <- filter(output, run_number %in% max_display$run_number)
 results_slice <- filter(results, run_number %in% max_display$run_number)
-
 ```
 
 # Results
@@ -246,9 +245,9 @@ ggplot(temp, aes(year, fill = source, color = source)) +
        y = expression(degree*C))
 ```
 
-# Hector output graphs
+## Atmosphere sources
 
-``` {r atmosphere-by-source, fig.cap = " Fraction of CO2 in the atmosphere by source pool"}
+``` {r atmosphere-by-source, fig.cap = " Fraction of CO2 in the atmosphere by source pool from 30 random runs. Dark line shows the median."}
 # This code just looks at the atmosphere pool
 atmos <- output_slice %>%
   filter(pool_name == "atmos_c")
@@ -265,10 +264,9 @@ ggplot(atmos, aes(year, source_fraction, color = as.factor(run_number), group = 
                geom = "line", 
                group = "run_number",
                size = 0.7)
-
 ```
 
-``` {r coeff-var, fig.cap = " Coefficients of variability for each source in the atmosphere over time"}
+``` {r coeff-var, fig.cap = " Coefficients of variability for each source in the atmosphere over time."}
 # Compute coefficient of variability for each source in the atmosphere pool
 atmos_cv <- atmos %>%
   group_by(year, source_name) %>%
@@ -283,12 +281,10 @@ ggplot(atmos_cv, aes(year, cv, group = source_name, color = source_name)) +
   # Could add facets to look at variability, but more useful to compare CV
   #facet_wrap(~source_name, scales = "free") +
   labs(x = "Source fraction",
-       y = "CV",
-       title = "Coefficients of variability by source in the atmosphere pool")
-
+       y = "CV")
 ```
 
-``` {r earthc-in-atmos, fig.cap = " Source of carbon in the atmosphere from fossil fuel over time"}
+``` {r earthc-in-atmos, fig.cap = " Fraction of atmospheric carbon from fossil fuel and industrial (FFI) emissions over time. Line shows median; shaded areas show ±1 s.d. of median (darker) and minimum and maximum of ensemble (lighter)."}
 # This chunk looks at the atmosphere pool with just one source (earth_c) 
 # and plots source fraction over time with a mean and confidence interval
 
@@ -305,12 +301,12 @@ ggplot(ff, aes(year)) +
   geom_ribbon(aes(ymin = sf_min, ymax = sf_max), alpha = 0.2) +
   geom_ribbon(aes(ymin = sf_median - sf_sd, ymax = sf_median + sf_sd), alpha = 0.2) +
   labs(x = "Year",
-       y = "Source fraction")
+       y = "Fraction tmospheric C derived from FFI emissions")
 ```
 
-# Where does carbon end up?
+## Destination of FFI emissions
 
-```{r destination, fig.cap = " Final destination pool of human emissions"}
+```{r destination, fig.cap = " Final destination pools of fossil fuel and industrial (FFI) emissions for 30 random runs."}
 # Where does carbon end up?
 # We have pool_name, source_name, source_fraction
 # Step 1: compute source_quantity = pool_value * source_fraction
@@ -337,12 +333,10 @@ ggplot(dest_runs, aes(year, destination_fraction,
         strip.text.x = element_blank(),
         axis.text.x = element_text(angle = 90)) +
   labs(x = "Year",
-       y = "Destination fraction")
+       y = "Destination of FFI emissions (fraction)")
 ```
 
-# All parameter combinations
-
-```{r parameter-space, fig.cap = " Parameter correlation"}
+```{r parameter-space, fig.cap = " Parameter correlations and distributions (diagonal), with color indicating XXX."}
 # Single time point, pool, and source - exploring how the parameter space 
 # is linked to output
 
@@ -362,9 +356,8 @@ ggpairs(single,
   scale_fill_viridis_d()
 ```
 
-# What controls how much earth_c ends up in the atmosphere?
 
-```{r relative-importance, fig.cap = " Relative importance of parameters over time"}
+```{r relative-importance, fig.cap = " Relative importance of parameters over time in controlling atmosphere as a destination of fossil fuel and industrial (FFI) emissions."}
 # Filter to just atmosphere pool, and remove unneeded columns
 dest_e2a <- filter(destination, pool_name == "atmos_c")
 dest_e2a_minimal <- dest_e2a[c("year", "destination_fraction", names(name_vector))]
@@ -399,10 +392,11 @@ ggplot(relimp_out, aes(year, value, fill = param)) +
   coord_cartesian(expand = FALSE) +
   scale_fill_viridis_d(direction = -1) +
   labs(x = "Year",
-       y = "Fraction of relative importance")
+       y = expression(Relative~importance~"for"~ƒFFI[atm]))
 ```
 
-# BBL AF
+## Airborne fraction
+
 ```{r airborne, warning = FALSE, fig.cap = " Mathematically defined airborne fraction with a line depicting the actual amount of human emissions that remains in the atmosphere"}
 # Prep the data
 os_atm_earth <- output_slice %>%
@@ -510,12 +504,11 @@ ggplot(data = plot_r, aes(year, group = run_number,
   theme(legend.position = "none") +
   labs(x = "Year",
        y = "Airborne fraction")
-
-
 ```
 
 
-# Airborne fraction
+## Airborne fraction
+
 ``` {r AF, fig.cap = " Airborne fraction over time"}
 # To calculate the airborne fraction, we need to find how much earth_c
 # flows to the atmos_c pool from time t to t+1 and divide by the difference
@@ -556,4 +549,10 @@ de %>%
   labs(x = "Year",
        y = "Airborne fraction")
 
+```
+
+# The End
+
+```{r}
+sessionInfo()
 ```

--- a/trackingC.Rmd
+++ b/trackingC.Rmd
@@ -1,7 +1,7 @@
 ---
 title: "trackingC.Rmd"
 author: "Leeya Pressburger"
-date: "2/3/2022"
+date: "`r Sys.Date()`"
 output:
   bookdown::html_document2:
     fig_caption: yes
@@ -163,7 +163,7 @@ tdata <- list()
 for(n in seq_len(length(out))){
   tdata[[n]] <- out[[n]]$tdata
 }
-output <- bind_rows(tdata, .id = "run_number") %>% as_tibble
+trk_output <- bind_rows(tdata, .id = "run_number") %>% as_tibble
 
 # Then, access model output data
 results <- list()
@@ -174,16 +174,17 @@ results <- bind_rows(results, .id = "run_number") %>% as_tibble()
 
 # Can left join with runlist to get param values
 # Make sure data is same class
-output$run_number <- as.integer(output$run_number)
-output <- left_join(output, runlist, by = "run_number")
+trk_output$run_number <- as.integer(trk_output$run_number)
+trk_output <- left_join(trk_output, runlist, by = "run_number")
 
 results$run_number <- as.integer(results$run_number)
 results <- left_join(results, runlist, by = "run_number")
 
-# If there are over 100 observations per time point, we want to use slice_sample() to randomly select rows to plot.
+# If there are over 100 observations per time point, 
+# we use slice_sample() to randomly select rows to plot.
 # Pull random run numbers from the runlist and filter output by random runs
 max_display <- slice_sample(runlist, n = 100)
-output_slice <- filter(output, run_number %in% max_display$run_number)
+trk_output_slice <- filter(trk_output, run_number %in% max_display$run_number)
 results_slice <- filter(results, run_number %in% max_display$run_number)
 ```
 
@@ -249,7 +250,7 @@ ggplot(temp, aes(year, fill = source, color = source)) +
 
 ``` {r atmosphere-by-source, fig.cap = " Fraction of CO2 in the atmosphere by source pool from 30 random runs. Dark line shows the median."}
 # This code just looks at the atmosphere pool
-atmos <- output_slice %>%
+atmos <- trk_output_slice %>%
   filter(pool_name == "atmos_c")
 
 # This plot looks at source fraction by source pool in the atmosphere as well as the median run.
@@ -313,7 +314,7 @@ ggplot(ff, aes(year)) +
 # Step 2: for each year and source_name, compute destination_fraction
 # group_by(year, source_name) %>% mutate(destination_fraction = source_quantity / sum(source_quantity))
 
-destination <- output_slice %>%
+ffi_destinations <- trk_output %>%
   filter(source_name == "earth_c", pool_name != "earth_c") %>%
   mutate(source_quantity = pool_value * source_fraction) %>%
   group_by(year, run_number) %>%
@@ -322,7 +323,7 @@ destination <- output_slice %>%
   ungroup()
 
 # Just looking at particular runs
-dest_runs <- filter(destination, run_number %in% c(1:30))
+dest_runs <- filter(ffi_destinations, run_number %in% c(1:30))
 
 ggplot(dest_runs, aes(year, destination_fraction, 
                    fill = pool_name)) +
@@ -336,18 +337,18 @@ ggplot(dest_runs, aes(year, destination_fraction,
        y = "Destination of FFI emissions (fraction)")
 ```
 
-```{r parameter-space, fig.cap = " Parameter correlations and distributions (diagonal), with color indicating XXX."}
+```{r parameter-space, fig.cap = " Parameter correlations and distributions (diagonal), with color indicating XXX, for the year 2100."}
 # Single time point, pool, and source - exploring how the parameter space 
 # is linked to output
 
-single <- output %>%
+ffi_atm_2100 <- trk_output %>%
   filter(pool_name == "atmos_c",
          source_name == "earth_c",
          year == 2100) %>% 
   mutate(sf = cut(source_fraction, 3))
 
 n <- length(name_vector)
-ggpairs(single,
+ggpairs(ffi_atm_2100,
         columns = 9:(9 + (n-1)),
         aes(color = sf), 
         diag = list(mapping = aes(alpha = 0.5)),
@@ -359,7 +360,7 @@ ggpairs(single,
 
 ```{r relative-importance, fig.cap = " Relative importance of parameters over time in controlling atmosphere as a destination of fossil fuel and industrial (FFI) emissions."}
 # Filter to just atmosphere pool, and remove unneeded columns
-dest_e2a <- filter(destination, pool_name == "atmos_c")
+dest_e2a <- filter(ffi_destinations, pool_name == "atmos_c")
 dest_e2a_minimal <- dest_e2a[c("year", "destination_fraction", names(name_vector))]
 
 # Function to calculate relative importance of parameters in
@@ -397,9 +398,9 @@ ggplot(relimp_out, aes(year, value, fill = param)) +
 
 ## Airborne fraction
 
-```{r airborne, warning = FALSE, fig.cap = " Mathematically defined airborne fraction with a line depicting the actual amount of human emissions that remains in the atmosphere"}
+```{r af-windows, fig.cap = " Airborne fraction computed over varying time windows."}
 # Prep the data
-os_atm_earth <- output_slice %>%
+os_atm_earth <- trk_output %>%
   # Isolate atmosphere and earth total pool values
   filter(pool_name %in% c("atmos_c", "earth_c")) %>% 
   group_by(run_number, year, pool_name) %>% 
@@ -434,21 +435,19 @@ for (groupsize in seq(1, 40, length.out = 10)) {
 af_results <- bind_rows(af_results, .id = "window_size") %>% 
   mutate(window_size = as.integer(window_size))
 
-results <- af_results %>%
-  group_by(group, year) %>%
-  mutate(sdev = sd(af, na.rm = TRUE),
-         minimum = min(af),
-         maximum = max(af),
-         med = median(af))
-
 af_results %>% 
   group_by(year, window_size) %>% 
-  summarise(af = mean(af)) %>% 
+  summarise(af = mean(af), .groups = "drop") %>% 
   ggplot(aes(year, af, color = window_size, group = window_size)) + 
-  geom_line() + ggtitle("AF computed using various time windows")
+  geom_line(na.rm = TRUE) + 
+  xlab("Year") + ylab("Airborne fraction")
+```
+
+
+```{r airborne, warning = FALSE, fig.cap = " Mathematically defined airborne fraction with a line depicting the actual amount of human emissions remaining in the atmosphere"}
 
 # Overlay with the fraction of emissions remaining in the atmosphere
-ea <- output_slice %>%
+ea <- trk_output_slice %>%
   select(-c(names(name_vector))) %>%
   # Isolate earth_c emissions in atmos_c
   filter(pool_name == "atmos_c", 
@@ -461,13 +460,14 @@ ea <- output_slice %>%
          frac = diff_source / cumulative)
 
 # Compute cumulative emissions over time
-# Destination
-emissions <- output_slice %>%
+# We use the change in earth_c to compute emissions; note this will not work
+# if ever using a scenario with fossil fuel sequestration (atmosphere -> earth)
+emissions <- trk_output_slice %>%
   filter(pool_name == "earth_c",
          source_name == "earth_c",
          run_number == min(run_number)) %>%
   arrange(year) %>%
-  mutate(emissions = c(0, diff(pool_value)),
+  mutate(emissions = -c(0, diff(pool_value)),
          # relative to 2000
          cumulative_emissions = cumsum(emissions)) %>%
   select(year, cumulative_emissions)
@@ -475,20 +475,28 @@ emissions <- output_slice %>%
 # Compute what fraction of cumulative emissions are in the atmosphere for each year
 # Destination
 # Airborne fraction - what fraction remains in atmosphere (when math breaks down - yay tracking)
-emissions_fraction <- output_slice %>%
+emissions_fraction <- trk_output_slice %>%
   filter(pool_name == "atmos_c", 
          source_name == "earth_c") %>%
   # How much earth_c is in atmos_c? 
   mutate(source_quantity = pool_value * source_fraction) %>%
   left_join(emissions, by = "year") %>%
   select(run_number, year, source_quantity, cumulative_emissions) %>%
-  mutate(c_emissions_fraction = -1 *(source_quantity / cumulative_emissions)) %>% 
+  mutate(c_emissions_fraction = source_quantity / cumulative_emissions) %>% 
   group_by(year) %>%
   summarize(sdev = sd(c_emissions_fraction),
             med = median(c_emissions_fraction),
             minimum = min(c_emissions_fraction),
             maximum = max(c_emissions_fraction))
-  
+
+# LEEYAP - YOU ALREADY HAVE A 'RESULTS' VARIABLE; DON'T OVERWRITE!
+results <- af_results %>%
+  group_by(group, year) %>%
+  mutate(sdev = sd(af, na.rm = TRUE),
+         minimum = min(af),
+         maximum = max(af),
+         med = median(af))
+
 plot_r <- results %>% 
  filter(window_size == 1)
 
@@ -506,10 +514,9 @@ ggplot(data = plot_r, aes(year, group = run_number,
        y = "Airborne fraction")
 ```
 
+## Airborne fraction (old)
 
-## Airborne fraction
-
-``` {r AF, fig.cap = " Airborne fraction over time"}
+``` {r AF, fig.cap = " Airborne fraction over time."}
 # To calculate the airborne fraction, we need to find how much earth_c
 # flows to the atmos_c pool from time t to t+1 and divide by the difference
 # in earth_c from t to t+1
@@ -519,7 +526,7 @@ pad  <- function(x, n) {
     c(rep(0, len.diff), x) 
 } 
 
-ea <- output_slice %>%
+ea <- trk_output_slice %>%
   # Isolate earth_c emissions in atmos_c
   filter(pool_name == "atmos_c", 
          source_name == "earth_c") %>%
@@ -529,7 +536,7 @@ ea <- output_slice %>%
   # Compute year-to-year difference
   mutate(e_in_a = pad(diff(source_quantity), length(source_quantity))) 
 
-de <- output_slice %>%
+de <- trk_output_slice %>%
   # Isolate earth_c pool
   filter(pool_name == "earth_c",
          source_name == "earth_c") %>%

--- a/trackingC.Rmd
+++ b/trackingC.Rmd
@@ -325,7 +325,7 @@ ggplot(ff, aes(year)) +
   geom_ribbon(aes(ymin = sf_min, ymax = sf_max), alpha = 0.2) +
   geom_ribbon(aes(ymin = sf_median - sf_sd, ymax = sf_median + sf_sd), alpha = 0.2) +
   labs(x = "Year",
-       y = "Fraction tmospheric C derived from FFI emissions")
+       y = "Fraction atmospheric C derived from FFI emissions")
 ```
 
 ## Destination of FFI emissions

--- a/trackingC.Rmd
+++ b/trackingC.Rmd
@@ -284,12 +284,12 @@ atmos <- trk_output_slice %>%
   filter(pool_name == "atmos_c")
 
 # This plot looks at source fraction by source pool in the atmosphere as well as the median run.
-ggplot(atmos, aes(year, source_fraction, color = as.factor(run_number), group = run_number)) +
+ggplot(atmos, aes(year, source_fraction, color = pool_name, group = run_number), alpha = 0.15) +
   geom_line(size = 0.5, show.legend = FALSE) +
   facet_wrap(~source_name, scales = "free") +
   labs(x = "Year",
        y = "Source fraction") +
-  scale_color_grey(start = 0.7, end = 0.7) +
+  scale_color_viridis_d() +
   stat_summary(color = "black",
                fun = median, 
                geom = "line", 
@@ -479,20 +479,6 @@ af_results %>%
 
 
 ```{r airborne, warning = FALSE, fig.cap = " Mathematically defined airborne fraction with a line depicting the actual amount of human emissions remaining in the atmosphere"}
-
-# Compute the fraction of emissions remaining in the atmosphere
-ea <- trk_output_slice %>%
-  select(-c(names(name_vector))) %>%
-  # Isolate earth_c emissions in atmos_c
-  filter(pool_name == "atmos_c", 
-         source_name == "earth_c") %>%
-  # How much earth_c is in atmos_c? What are cumulative emissions?
-  mutate(source_quantity = pool_value * source_fraction) %>%
-  group_by(run_number) %>%
-  mutate(cumulative = c(NA, cumsum(diff(source_quantity))),
-         diff_source = c(NA, diff(source_quantity)),
-         frac = diff_source / cumulative)
-
 # Compute cumulative emissions over time
 # We use the change in earth_c to compute emissions; note this will not work
 # if ever using a scenario with fossil fuel sequestration (atmosphere -> earth)
@@ -516,11 +502,12 @@ emissions_fraction <- trk_output_slice %>%
   select(run_number, year, source_quantity, cumulative_emissions) %>%
   mutate(c_emissions_fraction = source_quantity / cumulative_emissions) %>% 
   group_by(year) %>%
-  summarize(sdev = sd(c_emissions_fraction),
+  mutate(sdev = sd(c_emissions_fraction),
             med = median(c_emissions_fraction),
             minimum = min(c_emissions_fraction),
             maximum = max(c_emissions_fraction))
 
+# Classical definition of AF
 plot_r <- af_results %>%
   group_by(group, year) %>%
   mutate(sdev = sd(af, na.rm = TRUE),
@@ -528,18 +515,18 @@ plot_r <- af_results %>%
          maximum = max(af),
          med = median(af)) %>% 
   filter(window_size == 1,
-         run_number %in% ea$run_number)
+         run_number %in% emissions_fraction$run_number)
 
 # Plot the data
-ggplot(data = plot_r, aes(year, group = run_number,
+ggplot(data = plot_r, aes(year,
                    color = plot_r$window_size, 
                    fill = plot_r$window_size)) +
-  geom_ribbon(aes(ymin = minimum, ymax = maximum), alpha = 0.15) +
-  geom_ribbon(aes(ymin = med - sdev, ymax = med + sdev), alpha = 0.5) +
+  geom_ribbon(aes(ymin = minimum, ymax = maximum, group = run_number), alpha = 0.15) +
+  geom_ribbon(aes(ymin = med - sdev, ymax = med + sdev, group = run_number), alpha = 0.5) +
   scale_color_viridis_c() +
   scale_fill_viridis_c() +
   geom_line(aes(y = med), size = 1) +
-  geom_line(data = ea, aes(y = frac, group = run_number), color = "black") +
+  geom_line(data = emissions_fraction, aes(y = med), color = "black", na.rm = TRUE) +
   theme(legend.position = "none") +
   labs(x = "Year",
        y = "Airborne fraction")

--- a/trackingC.Rmd
+++ b/trackingC.Rmd
@@ -507,7 +507,7 @@ af_results %>%
 # Compute cumulative emissions over time
 # We use the change in earth_c to compute emissions; note this will not work
 # if ever using a scenario with fossil fuel sequestration (atmosphere -> earth)
-emissions <- trk_output_slice %>%
+emissions <- trk_output %>%
   filter(pool_name == "earth_c",
          source_name == "earth_c",
          run_number == min(run_number)) %>%
@@ -518,7 +518,7 @@ emissions <- trk_output_slice %>%
   select(year, cumulative_emissions)
   
 # Compute the fraction of fossil fuel emissions residing in the atmosphere
-emissions_fraction <- trk_output_slice %>%
+emissions_fraction <- trk_output %>%
   filter(pool_name == "atmos_c", 
          source_name == "earth_c") %>%
   # How much earth_c is in atmos_c? 
@@ -544,10 +544,12 @@ plot_r <- af_results %>%
 
 # Plot the data
 ggplot(data = plot_r, aes(year,
-                   color = plot_r$window_size, 
+                   color = plot_r$window_size,
                    fill = plot_r$window_size)) +
-  geom_ribbon(aes(ymin = minimum, ymax = maximum, group = run_number), alpha = 0.15) +
-  geom_ribbon(aes(ymin = med - sdev, ymax = med + sdev, group = run_number), alpha = 0.3) +
+  geom_ribbon(aes(ymin = minimum, ymax = maximum, group = run_number), 
+              alpha = 0.15, color = NA) +
+  geom_ribbon(aes(ymin = med - sdev, ymax = med + sdev, group = run_number), 
+              alpha = 0.5, color = NA) +
   geom_line(aes(y = med, size = 1)) +
   geom_line(data = emissions_fraction, aes(y = med), color = "black", na.rm = TRUE) +
   theme(legend.position = "none") +

--- a/trackingC.Rmd
+++ b/trackingC.Rmd
@@ -530,33 +530,51 @@ emissions_fraction <- trk_output %>%
   mutate(sdev = sd(c_emissions_fraction),
             med = median(c_emissions_fraction),
             minimum = min(c_emissions_fraction),
-            maximum = max(c_emissions_fraction))
+            maximum = max(c_emissions_fraction),
+         def = "EmissFraction")
 
 # Classical definition of AF
-plot_r <- af_results %>%
+classic_af <- af_results %>%
   group_by(group, year) %>%
   mutate(sdev = sd(af, na.rm = TRUE),
          minimum = min(af),
          maximum = max(af),
-         med = median(af)) %>% 
+         med = median(af),
+         def = "ClassicAF") %>% 
   filter(window_size == 1,
          run_number %in% emissions_fraction$run_number)
 
+# Isolate relevant parameters and plot
+plot_data <- bind_rows(emissions_fraction, classic_af) %>%
+  select(run_number, year, minimum, maximum, med, sdev, def)
+
+ggplot(plot_data, aes(x = year, group = paste0(def, run_number), fill = def)) +
+  geom_ribbon(aes(ymin = minimum, ymax = maximum), 
+              alpha = 0.05) +
+  geom_ribbon(aes(ymin = med - sdev, ymax = med + sdev), 
+              alpha = 0.10) +
+  geom_line(aes(y = med, color = def)) +
+  scale_color_viridis_d(begin = 0.5) +
+  scale_fill_viridis_d(begin = 0.5) +
+   labs(x = "Year",
+        y = "Airborne fraction")
+
+
 # Plot the data
-ggplot(data = plot_r, aes(year,
-                   color = plot_r$window_size,
-                   fill = plot_r$window_size)) +
-  geom_ribbon(aes(ymin = minimum, ymax = maximum, group = run_number), 
-              alpha = 0.15, color = NA) +
-  geom_ribbon(aes(ymin = med - sdev, ymax = med + sdev, group = run_number), 
-              alpha = 0.5, color = NA) +
-  geom_line(aes(y = med, size = 1)) +
-  geom_line(data = emissions_fraction, aes(y = med), color = "black", na.rm = TRUE) +
-  theme(legend.position = "none") +
-  scale_color_viridis_c() +
-  scale_fill_viridis_c() +
-  labs(x = "Year",
-       y = "Airborne fraction")
+# ggplot(data = plot_r, aes(year,
+#                    color = plot_r$window_size,
+#                    fill = plot_r$window_size)) +
+#   geom_ribbon(aes(ymin = minimum, ymax = maximum, group = run_number), 
+#               alpha = 0.15, color = NA) +
+#   geom_ribbon(aes(ymin = med - sdev, ymax = med + sdev, group = run_number), 
+#               alpha = 0.3, color = NA) +
+#   geom_line(aes(y = med, size = 1)) +
+#   geom_line(data = emissions_fraction, aes(y = med), color = "black", na.rm = TRUE) +
+#   theme(legend.position = "none") +
+#   scale_color_viridis_c(begin = 0.5) +
+#   scale_fill_viridis_c(begin = 0.5) +
+#   labs(x = "Year",
+#        y = "Airborne fraction")
 
 ```
 

--- a/trackingC.Rmd
+++ b/trackingC.Rmd
@@ -109,9 +109,9 @@ set.seed(10)
 # Function to access lognorm parameters with a desired mean and standard deviation
 # Reference: https://msalganik.wordpress.com/2017/01/21/making-sense-of-the-rlnorm-function-in-r/
 lognorm <- function(m, sd){
-  location <- log(m^2 / sqrt(sd^2 + m^2))
-  shape <- sqrt(log(1 + (sd^2 / m^2)))
-  v <- c(location, shape)
+  mn <- log(m^2 / sqrt(sd^2 + m^2))
+  stdev <- sqrt(log(1 + (sd^2 / m^2)))
+  v <- c(mn, stdev)
 }
 
 N_RUNS <- 1000
@@ -219,22 +219,22 @@ results <- list()
 for(n in seq_len(length(out))){
   results[[n]] <- out[[n]]$results
 }
-results <- bind_rows(results, .id = "run_number") %>% as_tibble()
+model_output <- bind_rows(results, .id = "run_number") %>% as_tibble()
 
 # Can left join with runlist to get param values
 # Make sure data is same class
 trk_output$run_number <- as.integer(trk_output$run_number)
 trk_output <- left_join(trk_output, runlist, by = "run_number")
 
-results$run_number <- as.integer(results$run_number)
-results <- left_join(results, runlist, by = "run_number")
+model_output$run_number <- as.integer(model_output$run_number)
+model_output <- left_join(model_output, runlist, by = "run_number")
 
 # If there are over 100 observations per time point, 
 # we use slice_sample() to randomly select rows to plot.
 # Pull random run numbers from the runlist and filter output by random runs
 max_display <- slice_sample(runlist, n = 100)
 trk_output_slice <- filter(trk_output, run_number %in% max_display$run_number)
-results_slice <- filter(results, run_number %in% max_display$run_number)
+model_output_slice <- filter(model_output, run_number %in% max_display$run_number)
 ```
 
 # Results
@@ -270,7 +270,7 @@ cmip <- read.csv("CMIP6_annual_tas_global.csv") %>%
   mutate(source = "CMIP6")
 
 # Extract Hector data
-hector <- results %>%
+hector <- model_output %>%
   filter(variable == "Tgav",
          year >= 2015 & year <= 2100) %>%
   group_by(year) %>%

--- a/trackingC.Rmd
+++ b/trackingC.Rmd
@@ -20,7 +20,11 @@ knitr::opts_chunk$set(echo = TRUE)
 
 # Methods
 
+## Definitions
+
 ## Setup
+
+### R setup
 
 Load necessary packages, read in an ini file and initiate core, and set seed for reproducibility.
 
@@ -48,7 +52,7 @@ set.seed(10)
 
 ```
 
-## Create dataset
+### Create runlist of parameter draws
 
 ```{r params}
 # Create runlist of parameters of interest
@@ -184,12 +188,12 @@ results_slice <- filter(results, run_number %in% max_display$run_number)
 
 ```
 
-# Data visualization
+# Results
 
 The following sections contain tentative figures in the order they would appear
 in a manuscript. 
 
-# Realized parameter PDFs
+## Realized parameter PDFs
 
 ``` {r params-PDFs, fig.cap = paste0(" Probability densities of each parameter (N=", N_RUNS, " draws).")}
 # Density plot to visualize parameter distributions
@@ -202,9 +206,9 @@ runlist %>%
   labs(x = NULL, y = NULL)
 ```
 
-# Hector temperature vs. CMIP6 
+## Hector temperature vs. CMIP6 
 
-``` {r cmip, fig.cap = " Global temperature anomaly outputs from CMIP6 and Hector runs."}
+``` {r cmip, fig.cap = " Global temperature anomaly from CMIP6 and Hector runs. Lines show median; shaded areas show ±1 s.d. of median (darker) and minimum and maximum of ensemble (lighter)."}
 # Read in comparison data
 cmip <- read.csv("CMIP6_annual_tas_global.csv") %>%
   filter(variable == "Tgav",
@@ -232,11 +236,12 @@ temp <- bind_rows(cmip, hector)
 
 # Plot temperature spread
 ggplot(temp, aes(year, fill = source, color = source)) +
-  geom_ribbon(aes(ymin = minimum, ymax = maximum), alpha = 0.15) +
-  geom_ribbon(aes(ymin = med - sdev, ymax = med + sdev), alpha = 0.5) +
-  geom_line(aes(y = med)) +
+  geom_ribbon(aes(ymin = minimum, ymax = maximum), alpha = 0.15, color = NA) +
+  geom_ribbon(aes(ymin = med - sdev, ymax = med + sdev), alpha = 0.5, color = NA) +
+  geom_line(aes(y = med), size = 2) +
   scale_color_viridis_d(begin = 0.5) +
   scale_fill_viridis_d(begin = 0.5) +
+  theme(legend.title = element_blank()) +
   labs(x = "Year",
        y = expression(degree*C))
 ```

--- a/trackingC.Rmd
+++ b/trackingC.Rmd
@@ -20,17 +20,31 @@ knitr::opts_chunk$set(echo = TRUE)
 
 ## Science background
 
-Basically the introductory sentences from existing google doc:
+* We are pumping massive amounts of carbon dioxide into the atmosphere. 
+Many studies have looked at the current dynamics of the C cycle, and/or 
+long-term ultimate fate of anthropogenic CO~2~.  
 
-* Point 1
-* Point 2
-* Point 3
+* Simple climate models are a useful tool to understanding the short-term 
+impacts of humans on the climate. In particular, the simple climate model 
+Hector 3.0.0 incorporates a novel carbon tracking feature, allowing the user to 
+trace the origins of CO~2~ as it moves through the Earth system.  
+
+* Using this model allows us to understand how sensitive Hector is to changing 
+parameters as well as determining the uncertainties in model projections.
 
 ## Goals
 
-* Goal 1
-* Goal 2
-* Goal 3
+Using Hector v3.0.0 and its novel carbon tracking feature, we want to:  
+
+* Understand the ultimate fate and distribution of anthropogenic CO~2~ and 
+its controls.  
+
+* Understand the uncertainties on the lifetime and fate of FFI emissions.  
+
+* Understand the uncertainties on the trends/robustness of airborne fraction as
+a metric for understanding how anthropogenic emissions influence the Earth system,
+and how Earth system feedbacks influence airborne fraction.
+
 
 # Methods
 
@@ -47,13 +61,18 @@ the ratio above will not exactly be that, because in some circumstances earth
 system feedbacks will add to atmospheric C as well. In addition, the 
 formula above produces negative numbers if $\Delta$ATM < 0.
 
-Could also use "A" (atmosphere) and "E" (emissions) above, if clearer?
 
 ## Setup
 
-We (describe methodology in a few bullets): random parameter draws from
-a priori PDFs from literature; parameterized Hector; ran XXX times; using
-both standard outputs (pools and fluxes) and carbon-tracking data.
+1. Create random parameter draw from a priori PDFs from literature (note that 
+we have not yet implemented joint PDFs).
+2. Parameterize Hector.
+3. Run Hector 1000 times (note that we are working on parallelizing this script
+to be run on pic, and the number of runs will scale up - at least 100,000?)
+4. Extracte standard output (pools and fluxes) and carbon tracking data. 
+5. Visualize data in four parts: sanity checks, graphs focusing on ƒATM~ffi~,
+graphs focusing on ƒFFI~atm~, and graphs of airborne fraction.
+
 
 ### R setup
 
@@ -76,7 +95,7 @@ ssp245 <- system.file("input/hector_ssp245.ini", package = "hector")
 core <- newcore(ssp245)
 
 # Set range of years for output data
-OUTPUT_YEARS <- 2000:2200
+OUTPUT_YEARS <- 1950:2200
 
 # Set random number generator to allow for reproducibility 
 set.seed(10)
@@ -145,7 +164,7 @@ run_hector <- function(pdata, c) {
     setvar(c, NA, do.call(p, list()), pdata[p][[1]], units_vector[p])
   }
   # Set a tracking date, reset and run core
-  setvar(c, NA, TRACKING_DATE(), 1750, NA)
+  setvar(c, NA, TRACKING_DATE(), 1950, NA)
   reset(c)
   run(c)
   # Access and save tracking data, model outputs
@@ -276,7 +295,7 @@ ggplot(temp, aes(year, fill = source, color = source)) +
        y = expression(degree*C))
 ```
 
-## Atmosphere sources
+## Atmosphere sources - ƒATM~ffi~
 
 ``` {r atmosphere-by-source, fig.cap = " Fraction of CO2 in the atmosphere by source pool from 30 random runs. Dark line shows the median."}
 # This code just looks at the atmosphere pool
@@ -284,12 +303,12 @@ atmos <- trk_output_slice %>%
   filter(pool_name == "atmos_c")
 
 # This plot looks at source fraction by source pool in the atmosphere as well as the median run.
-ggplot(atmos, aes(year, source_fraction, color = pool_name, group = run_number), alpha = 0.15) +
+ggplot(atmos, aes(year, source_fraction, color = as.factor(run_number), group = run_number)) +
   geom_line(size = 0.5, show.legend = FALSE) +
   facet_wrap(~source_name, scales = "free") +
   labs(x = "Year",
        y = "Source fraction") +
-  scale_color_viridis_d() +
+  scale_color_grey(start = 0.7, end = 0.7) +
   stat_summary(color = "black",
                fun = median, 
                geom = "line", 
@@ -327,17 +346,15 @@ ff <- atmos %>%
             sf_max = max(source_fraction),
             sf_median = median(source_fraction))
 
-ggplot(ff, aes(year, color = source_name, fill = source_name)) +
+ggplot(ff, aes(year)) +
   geom_line(aes(y = sf_median)) +
   geom_ribbon(aes(ymin = sf_min, ymax = sf_max), alpha = 0.2) +
   geom_ribbon(aes(ymin = sf_median - sf_sd, ymax = sf_median + sf_sd), alpha = 0.2) +
-  scale_color_viridis_d() +
-  scale_fill_viridis_d() +
   labs(x = "Year",
        y = "Fraction atmospheric C derived from FFI emissions")
 ```
 
-## Destination of FFI emissions
+## Destination of FFI emissions - ƒFFI~atm~
 
 ```{r destination, fig.cap = " Final destination pools of fossil fuel and industrial (FFI) emissions for 30 random runs."}
 # Where does carbon end up?

--- a/trackingC.Rmd
+++ b/trackingC.Rmd
@@ -18,11 +18,35 @@ knitr::opts_chunk$set(echo = TRUE)
 
 # Introduction
 
+## Science background
+
+Basically the introductory sentences from existing google doc:
+
+* Point 1
+* Point 2
+* Point 3
+
+## Goals
+
+* Goal 1
+* Goal 2
+* Goal 3
+
 # Methods
 
 ## Definitions
 
+* ƒATM~ffi~: the fraction of atmospheric carbon derived from fossil fuel industrial emissions
+* ƒFFI~atm~: the fraction of fossil fuel emissions residing in the atmosphere
+* AF: airborne fraction, conventionally computed as $\Delta$ATM / $\Sigma$FFI over some time period
+
+Could also use "A" (atmosphere) and "E" (emissions) above, if clearer?
+
 ## Setup
+
+We <describe methodology in a few bullets>: random parameter draws from
+a priori PDFs from literature; parameterized Hector; ran XXX times; using
+both standard outputs (pools and fluxes) and carbon-tracking data.
 
 ### R setup
 
@@ -49,7 +73,6 @@ years <- 2000:2200
 
 # Set random number generator to allow for reproducibility 
 set.seed(10)
-
 ```
 
 ### Create runlist of parameter draws
@@ -555,7 +578,6 @@ de %>%
   scale_color_viridis_c() +
   labs(x = "Year",
        y = "Airborne fraction")
-
 ```
 
 # The End

--- a/trackingC.Rmd
+++ b/trackingC.Rmd
@@ -297,23 +297,26 @@ ggplot(temp, aes(year, fill = source, color = source)) +
 
 ## Atmosphere sources - ƒATM~ffi~
 
-``` {r atmosphere-by-source, fig.cap = " Fraction of CO2 in the atmosphere by source pool from 30 random runs. Dark line shows the median."}
+``` {r atmosphere-by-source, fig.cap = " Fraction of CO2 in the atmosphere by source pool from 100 random runs. Dark line shows the median."}
 # This code just looks at the atmosphere pool
-atmos <- trk_output_slice %>%
+atmos <- trk_output %>%
   filter(pool_name == "atmos_c")
 
 # This plot looks at source fraction by source pool in the atmosphere as well as the median run.
-ggplot(atmos, aes(year, source_fraction, color = as.factor(run_number), group = run_number)) +
+atmos %>%
+  filter(run_number %in% max_display$run_number) %>%
+  ggplot(aes(year, source_fraction, 
+             color = as.factor(run_number), group = run_number)) +
   geom_line(size = 0.5, show.legend = FALSE) +
-  facet_wrap(~source_name, scales = "free") +
+  facet_wrap( ~ source_name, scales = "free") +
   labs(x = "Year",
        y = "Source fraction") +
   scale_color_grey(start = 0.7, end = 0.7) +
   stat_summary(color = "black",
-               fun = median, 
-               geom = "line", 
-               group = "run_number",
-               size = 0.7)
+    fun = median,
+    geom = "line",
+    group = "run_number",
+    size = 0.7)
 ```
 
 ``` {r coeff-var, fig.cap = " Coefficients of variability for each source in the atmosphere over time."}
@@ -544,12 +547,12 @@ ggplot(data = plot_r, aes(year,
                    color = plot_r$window_size, 
                    fill = plot_r$window_size)) +
   geom_ribbon(aes(ymin = minimum, ymax = maximum, group = run_number), alpha = 0.15) +
-  geom_ribbon(aes(ymin = med - sdev, ymax = med + sdev, group = run_number), alpha = 0.5) +
-  scale_color_viridis_c() +
-  scale_fill_viridis_c() +
-  geom_line(aes(y = med), size = 1) +
+  geom_ribbon(aes(ymin = med - sdev, ymax = med + sdev, group = run_number), alpha = 0.3) +
+  geom_line(aes(y = med, size = 1)) +
   geom_line(data = emissions_fraction, aes(y = med), color = "black", na.rm = TRUE) +
   theme(legend.position = "none") +
+  scale_color_viridis_c() +
+  scale_fill_viridis_c() +
   labs(x = "Year",
        y = "Airborne fraction")
 

--- a/trackingC.Rmd
+++ b/trackingC.Rmd
@@ -22,7 +22,13 @@ knitr::opts_chunk$set(echo = TRUE, warning = FALSE)
 
 * We are pumping massive amounts of carbon dioxide into the atmosphere. 
 Many studies have looked at the current dynamics of the C cycle, and/or 
-long-term ultimate fate of anthropogenic CO~2~.  
+long-term ultimate fate of anthropogenic CO~2~.
+
+* There are many uncertainties surrounding the trend of airborne fraction
+(thought of as how much anthropogenic remains in the atmosphere, though
+see below), and more generally surrounding feedbacks and processes in the
+earth system controlling the growth of atmospheric CO~2~ 
+and thus radiative forcing.
 
 * Simple climate models are a useful tool to understanding the short-term 
 impacts of humans on the climate. In particular, the simple climate model 
@@ -68,10 +74,15 @@ formula above produces negative numbers if $\Delta$ATM < 0.
 we have not yet implemented joint PDFs).
 2. Parameterize Hector.
 3. Run Hector 1000 times (note that we are working on parallelizing this script
-to be run on pic, and the number of runs will scale up - at least 100,000?)
+to be run on pic, and the number of runs will scale up - at least 100,000?). 
+4. Note that we currently turn tracking on at 1950--i.e., at this date
+everything is assumed to be "pure" (atmosphere is 100% atmosphere, etc.) 
+and things move and mix from there.
 4. Extract standard output (pools and fluxes) and carbon tracking data. 
-5. Visualize data in four parts: sanity checks, graphs focusing on ƒATM~ffi~,
-graphs focusing on ƒFFI~atm~, and graphs of airborne fraction.
+5. Visualize data in four parts: sanity checks, graphs focusing on ƒATM~ffi~ 
+(i.e., patterns and dynamics of the origin of atmospheric C),
+graphs focusing on ƒFFI~atm~ (i.e., controls on the destination of FFI C), 
+and graphs of airborne fraction.
 
 
 ### R setup
@@ -395,7 +406,7 @@ ggplot(dest_runs, aes(year, destination_fraction,
        y = "Destination of FFI emissions (fraction)")
 ```
 
-```{r parameter-space, fig.cap = " Parameter correlations and distributions (diagonal), with color indicating XXX, for the year 2100."}
+```{r parameter-space, fig.cap = " Parameter correlations and distributions (diagonal), with color indicating how much of the atmosphere is composed of anthropogenic carbon in the year 2100."}
 # Single time point, pool, and source - exploring how the parameter space 
 # is linked to output
 
@@ -416,7 +427,7 @@ ggpairs(ffi_atm_2100,
 ```
 
 
-```{r relative-importance, fig.cap = " Relative importance of parameters over time in controlling atmosphere as a destination of fossil fuel and industrial (FFI) emissions."}
+```{r relative-importance, message=FALSE, warning=FALSE, fig.cap = " Relative importance of parameters over time in controlling atmosphere as a destination of fossil fuel and industrial (FFI) emissions."}
 # Filter to just atmosphere pool, and remove unneeded columns
 dest_e2a <- filter(ffi_destinations, pool_name == "atmos_c")
 dest_e2a_minimal <- dest_e2a[c("year", "destination_fraction", names(name_vector))]
@@ -509,7 +520,7 @@ af_results %>%
 ```
 
 
-```{r airborne, warning = FALSE, fig.cap = " Mathematically defined airborne fraction with a line depicting the actual amount of human emissions remaining in the atmosphere"}
+```{r airborne, warning = FALSE, fig.cap = " Year-by-year mathematically defined airborne fraction. The yellow line and band shows the actual amount of human emissions remaining in the atmosphere from the model's carbon-tracking mechanism."}
 # Compute cumulative emissions over time
 # We use the change in earth_c to compute emissions; note this will not work
 # if ever using a scenario with fossil fuel sequestration (atmosphere -> earth)
@@ -554,7 +565,7 @@ classic_af <- af_results %>%
 plot_data <- bind_rows(emissions_fraction, classic_af) %>%
   select(run_number, year, minimum, maximum, med, sdev, def)
 
-ggplot(plot_data, aes(x = year, group = paste0(def, run_number), fill = def)) +
+ggplot(plot_data, aes(x = year, fill = def)) +
   geom_ribbon(aes(ymin = minimum, ymax = maximum), 
               alpha = 0.15) +
   geom_ribbon(aes(ymin = med - sdev, ymax = med + sdev), 

--- a/trackingC.Rmd
+++ b/trackingC.Rmd
@@ -359,7 +359,7 @@ ggplot(ff, aes(year)) +
 
 ## Destination of FFI emissions - ƒFFI~atm~
 
-```{r destination, fig.cap = " Final destination pools of fossil fuel and industrial (FFI) emissions for 30 random runs."}
+```{r destination, fig.cap = " Final destination pools of fossil fuel and industrial (FFI) emissions for 16 random runs."}
 # Where does carbon end up?
 # We have pool_name, source_name, source_fraction
 # Step 1: compute source_quantity = pool_value * source_fraction
@@ -375,7 +375,7 @@ ffi_destinations <- trk_output %>%
   ungroup()
 
 # Just looking at particular runs
-dest_runs <- filter(ffi_destinations, run_number %in% c(1:30))
+dest_runs <- filter(ffi_destinations, run_number %in% c(1:16))
 
 ggplot(dest_runs, aes(year, destination_fraction, 
                    fill = pool_name)) +

--- a/trackingC.Rmd
+++ b/trackingC.Rmd
@@ -144,8 +144,8 @@ run_hector <- function(pdata, c) {
     message("\tSetting ", p)
     setvar(c, NA, do.call(p, list()), pdata[p][[1]], units_vector[p])
   }
-  # Set a tracking data, reset and run core
-  setvar(c, NA, TRACKING_DATE(), 1950, NA)
+  # Set a tracking date, reset and run core
+  setvar(c, NA, TRACKING_DATE(), 1750, NA)
   reset(c)
   run(c)
   # Access and save tracking data, model outputs
@@ -322,15 +322,17 @@ ggplot(atmos_cv, aes(year, cv, group = source_name, color = source_name)) +
 ff <- atmos %>% 
   filter(source_name == "earth_c") %>%
   group_by(year) %>%
-  summarize(sf_sd = sd(source_fraction), 
+  mutate(sf_sd = sd(source_fraction), 
             sf_min = min(source_fraction),
             sf_max = max(source_fraction),
             sf_median = median(source_fraction))
 
-ggplot(ff, aes(year)) +
+ggplot(ff, aes(year, color = source_name, fill = source_name)) +
   geom_line(aes(y = sf_median)) +
   geom_ribbon(aes(ymin = sf_min, ymax = sf_max), alpha = 0.2) +
   geom_ribbon(aes(ymin = sf_median - sf_sd, ymax = sf_median + sf_sd), alpha = 0.2) +
+  scale_color_viridis_d() +
+  scale_fill_viridis_d() +
   labs(x = "Year",
        y = "Fraction atmospheric C derived from FFI emissions")
 ```
@@ -470,13 +472,15 @@ af_results %>%
   summarise(af = mean(af), .groups = "drop") %>% 
   ggplot(aes(year, af, color = window_size, group = window_size)) + 
   geom_line(na.rm = TRUE) + 
-  xlab("Year") + ylab("Airborne fraction")
+  labs(x = "Year",
+       y = "Airborne fraction")
+
 ```
 
 
 ```{r airborne, warning = FALSE, fig.cap = " Mathematically defined airborne fraction with a line depicting the actual amount of human emissions remaining in the atmosphere"}
 
-# Overlay with the fraction of emissions remaining in the atmosphere
+# Compute the fraction of emissions remaining in the atmosphere
 ea <- trk_output_slice %>%
   select(-c(names(name_vector))) %>%
   # Isolate earth_c emissions in atmos_c
@@ -502,9 +506,7 @@ emissions <- trk_output_slice %>%
          cumulative_emissions = cumsum(emissions)) %>%
   select(year, cumulative_emissions)
   
-# Compute what fraction of cumulative emissions are in the atmosphere for each year
-# Destination
-# Airborne fraction - what fraction remains in atmosphere (when math breaks down - yay tracking)
+# Compute the fraction of fossil fuel emissions residing in the atmosphere
 emissions_fraction <- trk_output_slice %>%
   filter(pool_name == "atmos_c", 
          source_name == "earth_c") %>%
@@ -519,22 +521,21 @@ emissions_fraction <- trk_output_slice %>%
             minimum = min(c_emissions_fraction),
             maximum = max(c_emissions_fraction))
 
-# LEEYAP - YOU ALREADY HAVE A 'RESULTS' VARIABLE; DON'T OVERWRITE!
-results <- af_results %>%
+plot_r <- af_results %>%
   group_by(group, year) %>%
   mutate(sdev = sd(af, na.rm = TRUE),
          minimum = min(af),
          maximum = max(af),
-         med = median(af))
+         med = median(af)) %>% 
+  filter(window_size == 1,
+         run_number %in% ea$run_number)
 
-plot_r <- results %>% 
- filter(window_size == 1)
-
+# Plot the data
 ggplot(data = plot_r, aes(year, group = run_number,
                    color = plot_r$window_size, 
                    fill = plot_r$window_size)) +
-  geom_ribbon(aes(ymin = minimum, ymax = maximum), alpha = 0.01) +
-  geom_ribbon(aes(ymin = med - sdev, ymax = med + sdev), alpha = 0.02) +
+  geom_ribbon(aes(ymin = minimum, ymax = maximum), alpha = 0.15) +
+  geom_ribbon(aes(ymin = med - sdev, ymax = med + sdev), alpha = 0.5) +
   scale_color_viridis_c() +
   scale_fill_viridis_c() +
   geom_line(aes(y = med), size = 1) +
@@ -542,53 +543,11 @@ ggplot(data = plot_r, aes(year, group = run_number,
   theme(legend.position = "none") +
   labs(x = "Year",
        y = "Airborne fraction")
-```
 
-## Airborne fraction (old)
-
-``` {r AF, fig.cap = " Airborne fraction over time."}
-# To calculate the airborne fraction, we need to find how much earth_c
-# flows to the atmos_c pool from time t to t+1 and divide by the difference
-# in earth_c from t to t+1
-
-pad  <- function(x, n) {
-    len.diff <- n - length(x)
-    c(rep(0, len.diff), x) 
-} 
-
-ea <- trk_output_slice %>%
-  # Isolate earth_c emissions in atmos_c
-  filter(pool_name == "atmos_c", 
-         source_name == "earth_c") %>%
-  # How much earth_c is in atmos_c?
-  mutate(source_quantity = pool_value * source_fraction) %>%
-  group_by(run_number) %>%
-  # Compute year-to-year difference
-  mutate(e_in_a = pad(diff(source_quantity), length(source_quantity))) 
-
-de <- trk_output_slice %>%
-  # Isolate earth_c pool
-  filter(pool_name == "earth_c",
-         source_name == "earth_c") %>%
-  select(-c(names(name_vector))) %>%
-  mutate(e_in_a = ea$e_in_a) %>%
-  group_by(run_number) %>%
-  # Compute difference in pool over time and airborne fraction
-  mutate(delta_e = pad(diff(pool_value), length(pool_value)),
-         AF = round((e_in_a / -delta_e), 4))
-
-de %>% 
-  # Remove first row with NaN AF value
-  slice(-1) %>%
-  ggplot(aes(year, AF, group = run_number, color = AF)) +
-  geom_line() + 
-  scale_color_viridis_c() +
-  labs(x = "Year",
-       y = "Airborne fraction")
 ```
 
 # The End
 
-```{r}
+```{r info}
 sessionInfo()
 ```


### PR DESCRIPTION
Hello @leeyap , for Monday discussion, this PR:

* Restructures the Rmarkdown so that results are displayed as parameter PDFs; temperature plot; plots showing atmosphere sources; plots showing FFI emissions destinations; airborne fraction plots
* Expands captions to more clearly and completely describe figures
* Clarify variable naming, in particular what is now called `trk_output` (tracking data output)
* Straighten out when we use `trk_output_slice` and `results_slice` (only for figures _showing individual runs_) versus the full output datasets (all computations and figures showing median and ribbons)
* Add skeleton introductory material
* Propose a nomenclature for "fraction of atmosphere derived from FFI emissions" and "fraction of FFI emissions in atmosphere". We can discuss and change, but I think we need something like this
* And a "The End" section -- very important for reproducibility