### PR TITLE
One approach to joint PDF for ECS and diffusivity

### DIFF
--- a/trackingC.Rmd
+++ b/trackingC.Rmd
@@ -153,31 +153,35 @@ runlist <- tibble(
 # ECS (equilibrium climate sensitivity) and ocean heat diffusivity are 
 # notably correlated with each other, so use a joint PDF for these
 
-# ECS should be log-normally distributed, but N(3, 1) produces a curve
-# that's pretty close if we toss out all values <= 0 (about 0.3%)
+# ECS is log-normally distributed, but we will transform it to fit a 
+# normal distribution by taking the log of the entire distribution
 # If we do this, we can use MASS::mvrnorm() which saves us a LOT of work
 # writing a custom rejection sampling routine...
+# We will then transform the final values back to fit a lognormal distribution
+# by taking the exponential of our ECS values
+# Both distributions are currently Hector defaults
 ecs_vals_lognorm <- rlnorm(N_RUNS, lognorm(3, 1.0)[1], lognorm(3, 1.0)[2])
-ecs_vals <- rnorm(N_RUNS, mean = 3, sd = 1) # see note above
+ecs_vals_to_norm <- log(ecs_vals_lognorm)
 diffusion_vals <- rnorm(N_RUNS, mean = 2.3, sd = 0.23)
 
 DESIRED_PCOR <- -0.75  # ECS and diffusivity should be negatively correlated
 # https://en.wikipedia.org/wiki/Covariance_and_correlation
-desired_cov <- DESIRED_PCOR * sd(ecs_vals) * sd(diffusion_vals)
+desired_cov <- DESIRED_PCOR * sd(ecs_vals_to_norm) * sd(diffusion_vals)
 # Set up the variance-covariance matrix
-Sigma <- matrix(c(var(ecs_vals), 
+Sigma <- matrix(c(var(ecs_vals_to_norm), 
                   desired_cov, desired_cov, 
                   var(diffusion_vals)),
                 2, 2)
 # ...and generate values--twice as many as needed because we toss out
 # negative ECS values below (see note above)
-joint_vals <- MASS::mvrnorm(n = N_RUNS * 2, c(mean(ecs_vals), mean(diffusion_vals)), Sigma)
+joint_vals <- MASS::mvrnorm(n = N_RUNS * 2, c(mean(ecs_vals_to_norm), mean(diffusion_vals)), Sigma)
 jv <- as_tibble(joint_vals)
 colnames(jv) <- c("ECS", "DIFFUSIVITY")
 # Filter and bind to the runlist
 jv %>% 
   filter(ECS > 0) %>% 
-  sample_n(N_RUNS) %>% 
+  mutate(ECS = exp(ECS)) %>%
+  sample_n(N_RUNS) %>%
   bind_cols(runlist, .) ->
   runlist
 
@@ -187,11 +191,11 @@ p <- ggplot(runlist, aes(ECS, DIFFUSIVITY)) +
   geom_density_2d() +
   ggtitle("Joint distribution of ECS and DIFFUSIVITY")
 ggExtra::ggMarginal(p, type = "histogram", alpha = 0.2)
-# Visualize proper lognormal versus normal distributions for ECS
+# Visualize proper lognormal versus transformed distributions for ECS
 tibble(lognorm = ecs_vals_lognorm, norm = runlist$ECS) %>% 
   pivot_longer(everything()) %>% 
   ggplot(aes(value, fill = name)) + geom_density(alpha = 0.5) +
-  ggtitle("Comparison of (proper) lognormal with normal for ECS")
+  ggtitle("Comparison of (proper) lognormal with transformed distribution for ECS")
 
 # Name and units of parameters
 name_vector <- c("BETA" = BETA(), "Q10_RH" = Q10_RH(), 

--- a/trackingC.Rmd
+++ b/trackingC.Rmd
@@ -143,15 +143,42 @@ runlist <- tibble(
   "BETA" = rnorm(N_RUNS, mean = 0.54, sd = 0.03),
   # Davidson and Janssens (2006)
   "Q10_RH" = rlnorm(N_RUNS, lognorm(2, 1.0)[1], lognorm(2, 1.0)[2]),
-  # Hector default - note joint with diffusivity
-  "ECS" = rlnorm(N_RUNS, lognorm(3, 1.0)[1], lognorm(3, 1.0)[2]),
   # Ito (2011)
   "NPP_FLUX0" = rnorm(N_RUNS, mean = 56.2, sd = 5.62),
   # Hector default
-  "AERO_SCALE" = rnorm(N_RUNS, mean = 1.0, sd = 0.1),
-  # Hector default - note joint with ECS
-  "DIFFUSIVITY" = rnorm(N_RUNS, mean = 2.3, sd = 0.23),
+  "AERO_SCALE" = rnorm(N_RUNS, mean = 1.0, sd = 0.1)
 )
+
+# ECS (equilibrium climate sensitivity) and ocean heat diffusivity are 
+# notably correlated with each other, so use a joint PDF for these
+
+# ECS should be log-normally distributed, but a N(3, 2) produces a curve
+# that's pretty close if we toss out all values <= 0 (about 12%)
+# If we do this, we can use MASS::mvrnorm() which saves us a LOT of work
+# writing a custom rejection sampling routine...
+#ecs_vals <- rlnorm(N_RUNS, lognorm(3, 1.0)[1], lognorm(3, 1.0)[2])
+ecs_vals <- rnorm(N_RUNS, mean = 3, sd = 2) # see note above
+diff_vals <- rnorm(N_RUNS, mean = 2.3, sd = 0.23)
+
+DESIRED_PCOR <- -0.8  # ECS and diffusivity should be negatively correlated
+# https://en.wikipedia.org/wiki/Covariance_and_correlation
+desired_cov <- DESIRED_PCOR * sd(ecs_vals) * sd(diff_vals)
+# Set up the variance-covariance matrix
+Sigma <- matrix(c(var(ecs_vals), 
+                  desired_cov, desired_cov, 
+                  var(diff_vals)),
+                2, 2)
+# ...and generate values--twice as many as needed because we toss out
+# negative ECS values below (see note above)
+joint_vals <- MASS::mvrnorm(n = N_RUNS * 2, c(mean(ecs_vals), mean(diff_vals)), Sigma)
+jv <- as_tibble(joint_vals)
+colnames(jv) <- c("ECS", "DIFFUSIVITY")
+# Filter and bind to the runlist
+jv %>% 
+  filter(ECS > 0) %>% 
+  sample_n(N_RUNS) %>% 
+  bind_cols(runlist, .) ->
+  runlist
 
 # Name and units of parameters
 name_vector <- c("BETA" = BETA(), "Q10_RH" = Q10_RH(), 

--- a/trackingC.Rmd
+++ b/trackingC.Rmd
@@ -349,7 +349,8 @@ hector <- model_output %>%
   filter(variable == "Tgav",
          year >= 2015 & year <= 2100) %>%
   group_by(year) %>%
-  summarize(sdev = sd(value),
+  summarize(run_number = run_number,
+            sdev = sd(value),
             minimum = min(value),
             maximum = max(value),
             med = median(value)) %>%
@@ -358,8 +359,38 @@ hector <- model_output %>%
 # Combine data
 temp <- bind_rows(cmip, hector)
 
+# Filter out unrealistic values - for each run, if more than 50% of values are
+# outside of the min/max of the CMIP data, the run is nixed
+cmip_bounds <- cmip %>% select(year, minimum, maximum)
+hector_temp <- model_output %>%
+  filter(variable == "Tgav",
+         year >= 2015 & year <= 2100) %>%
+  group_by(year) %>%
+  mutate(hmin = min(value),
+         hmax = max(value)) %>%
+  select(run_number, year, hmin, hmax) %>%
+  left_join(cmip_bounds, by = "year")
+
+# Check if Hector outputs are within CMIP6 range
+for(n in seq_len(nrow(hector_temp))){
+  if(hector_temp$hmin[n] < hector_temp$minimum[n] | hector_temp$hmax[n] > hector_temp$maximum[n]) hector_temp$fail[n] <- "yes" else hector_temp$fail[n] <- "no"
+}
+
+# Filter for more than 50% "yes"
+# 86 entries per run number
+test <- hector_temp %>%
+  filter(fail == "yes") %>%
+  group_by(run_number) %>%
+  mutate(num_fails = length(run_number),
+         percent_fails = (num_fails / 86) * 100) %>%
+  filter(percent_fails > 50)
+
+bad_runs <- unique(test$run_number)
+
 # Plot temperature spreads
-ggplot(temp, aes(year, fill = source, color = source)) +
+temp %>%
+  filter(run_number %in% !bad_runs) %>%
+  ggplot(aes(year, fill = source, color = source)) +
   geom_ribbon(aes(ymin = minimum, ymax = maximum), alpha = 0.15, color = NA) +
   geom_ribbon(aes(ymin = med - sdev, ymax = med + sdev), alpha = 0.5, color = NA) +
   geom_line(aes(y = med), size = 2) +

--- a/trackingC.Rmd
+++ b/trackingC.Rmd
@@ -332,7 +332,7 @@ runlist %>%
 
 ## Hector temperature vs. CMIP6 
 
-``` {r cmip, fig.cap = " Global temperature anomaly from CMIP6 and Hector runs. Lines show median; shaded areas show ±1 s.d. of median (darker) and minimum and maximum of ensemble (lighter)."}
+``` {r cmip, fig.cap = " Global temperature anomaly from CMIP6 and filtered Hector runs. Lines show median; shaded areas show ±1 s.d. of median (darker) and minimum and maximum of ensemble (lighter)."}
 # Read in CMIP6 comparison data
 cmip <- read.csv("CMIP6_annual_tas_global.csv") %>%
   filter(variable == "Tgav",
@@ -344,54 +344,55 @@ cmip <- read.csv("CMIP6_annual_tas_global.csv") %>%
             med = median(value)) %>%
   mutate(source = "CMIP6")
 
-# Extract Hector data
-hector <- model_output %>%
-  filter(variable == "Tgav",
-         year >= 2015 & year <= 2100) %>%
-  group_by(year) %>%
-  summarize(run_number = run_number,
-            sdev = sd(value),
-            minimum = min(value),
-            maximum = max(value),
-            med = median(value)) %>%
-  mutate(source = "Hector")
-
-# Combine data
-temp <- bind_rows(cmip, hector)
-
-# Filter out unrealistic values - for each run, if more than 50% of values are
+# Identify unrealistic runs - for each run, if more than 50% of values are
 # outside of the min/max of the CMIP data, the run is nixed
 cmip_bounds <- cmip %>% select(year, minimum, maximum)
 hector_temp <- model_output %>%
   filter(variable == "Tgav",
          year >= 2015 & year <= 2100) %>%
-  group_by(year) %>%
-  mutate(hmin = min(value),
-         hmax = max(value)) %>%
-  select(run_number, year, hmin, hmax) %>%
-  left_join(cmip_bounds, by = "year")
+  select(run_number, year, value) %>%
+  left_join(cmip_bounds, by = "year") %>% 
+  mutate(fail = value < minimum | value > maximum)
 
-# Check if Hector outputs are within CMIP6 range
-for(n in seq_len(nrow(hector_temp))){
-  if(hector_temp$hmin[n] < hector_temp$minimum[n] | 
-     hector_temp$hmax[n] > hector_temp$maximum[n]) hector_temp$fail[n] <- "yes" 
-  else hector_temp$fail[n] <- "no"
-}
-
-# Filter for more than 50% "yes"
-# 86 entries per run number
-test <- hector_temp %>%
-  filter(fail == "yes") %>%
+run_fail_summary <- hector_temp %>%
   group_by(run_number) %>%
-  mutate(num_fails = length(run_number),
-         percent_fails = (num_fails / 86) * 100) %>%
-  filter(percent_fails > 50)
+  summarise(fraction_fail = sum(fail) / n())
 
-bad_runs <- unique(test$run_number)
+# Make a table of failure rates
+run_fail_summary %>% 
+  group_by(fraction_fail > 0.5) %>% 
+  summarise(n()) %>% 
+  knitr::kable()
 
-# Plot temperature spreads
-temp %>%
-  filter(run_number %in% !bad_runs) %>%
+# ...and a figure 
+hector_temp %>% 
+  left_join(run_fail_summary, by = "run_number") %>% 
+  filter(run_number <= 100) %>% # this is a debugging figure; plot just 100 runs for clarity
+  ggplot(aes(year, value, color = fraction_fail, group = run_number)) + 
+  geom_line() + 
+  geom_point(aes(y = minimum), color = "red") + 
+  geom_point(aes(y = maximum), color = "red")
+
+# Filter out 'unrealistic' runs (identified above)
+model_output %>%
+  left_join(run_fail_summary, by = "run_number") %>% 
+  filter(fraction_fail < 0.5) ->
+  model_output_filtered
+
+# Plot temperature spreads for the filtered runs
+model_output_filtered %>%
+  filter(variable == "Tgav",
+         year >= 2015 & year <= 2100) %>% 
+  # compute median, min, max, etc. for all remaining runs
+  group_by(year) %>%
+  summarize(sdev = sd(value),
+            minimum = min(value),
+            maximum = max(value),
+            med = median(value), .groups = "drop") %>% 
+  # combine with CMIP6 data
+  mutate(source = "Hector") %>% 
+  bind_rows(cmip) %>% 
+  # ...and plot
   ggplot(aes(year, fill = source, color = source)) +
   geom_ribbon(aes(ymin = minimum, ymax = maximum), alpha = 0.15, color = NA) +
   geom_ribbon(aes(ymin = med - sdev, ymax = med + sdev), alpha = 0.5, color = NA) +

--- a/trackingC.Rmd
+++ b/trackingC.Rmd
@@ -126,7 +126,18 @@ Currently, we are looking at six Hector parameters: `BETA(), Q10_RH(), ECS(),
 NPP_FLUX0(), AERO_SCALE(), DIFFUSIVITY()`. We created a runlist with `r N_RUNS` random
 draws in a normal (or lognormal, where applicable) distribution.
 
-```{r params}
+ECS (equilibrium climate sensitivity) and ocean heat diffusivity are 
+notably correlated with each other, so we use a joint PDF for these.  
+
+ECS is log-normally distributed, but we will transform it to fit a 
+normal distribution by taking the log of the entire distribution.
+If we do this, we can use MASS::mvrnorm() which saves us a LOT of work in
+writing a custom rejection sampling routine...  
+
+We will then transform the final values back to fit a lognormal distribution
+by taking the exponential of our ECS values
+
+```{r runlist}
 # Create runlist of parameters of interest
 
 # Function to access lognorm parameters with a desired mean and standard deviation
@@ -150,17 +161,24 @@ runlist <- tibble(
   "AERO_SCALE" = rnorm(N_RUNS, mean = 1.0, sd = 0.1)
 )
 
-# ECS (equilibrium climate sensitivity) and ocean heat diffusivity are 
-# notably correlated with each other, so use a joint PDF for these
+# Name and units of all parameters
+name_vector <- c("BETA" = BETA(), "Q10_RH" = Q10_RH(), 
+                 "ECS" = ECS(), "NPP_FLUX0" = NPP_FLUX0(),
+                 "AERO_SCALE" = AERO_SCALE(), "DIFFUSIVITY" = DIFFUSIVITY()
+                 )
 
-# ECS is log-normally distributed, but we will transform it to fit a 
-# normal distribution by taking the log of the entire distribution
-# If we do this, we can use MASS::mvrnorm() which saves us a LOT of work
-# writing a custom rejection sampling routine...
-# We will then transform the final values back to fit a lognormal distribution
-# by taking the exponential of our ECS values
+units_vector <- c("BETA" = "(unitless)", "Q10_RH" = "(unitless)", 
+                  "ECS" = "degC", "NPP_FLUX0" = "Pg C/yr",
+                  "AERO_SCALE" = "(unitless)", "DIFFUSIVITY" = "cm2/s"
+                  )
+
+```
+
+``` {r joint-params, fig.cap = " The final joint distribution of ECS and diffusivity. The individual parameter distributions are shown on the x and y axes."}
+# Joint PDF for ECS and diffusivity
 # Both distributions are currently Hector defaults
 ecs_vals_lognorm <- rlnorm(N_RUNS, lognorm(3, 1.0)[1], lognorm(3, 1.0)[2])
+# Transform ECS distribution to log(distribution)
 ecs_vals_to_norm <- log(ecs_vals_lognorm)
 diffusion_vals <- rnorm(N_RUNS, mean = 2.3, sd = 0.23)
 
@@ -177,6 +195,7 @@ Sigma <- matrix(c(var(ecs_vals_to_norm),
 joint_vals <- MASS::mvrnorm(n = N_RUNS * 2, c(mean(ecs_vals_to_norm), mean(diffusion_vals)), Sigma)
 jv <- as_tibble(joint_vals)
 colnames(jv) <- c("ECS", "DIFFUSIVITY")
+
 # Filter and bind to the runlist
 jv %>% 
   mutate(ECS = exp(ECS)) %>%
@@ -191,22 +210,17 @@ p <- ggplot(runlist, aes(ECS, DIFFUSIVITY)) +
   geom_density_2d() +
   ggtitle("Joint distribution of ECS and DIFFUSIVITY")
 ggExtra::ggMarginal(p, type = "histogram", alpha = 0.2)
+
+```
+
+``` {r log-dist, fig.cap = " Comparing the original, random, lognormal distribution for ECS with the final transformed version, the exponential of the log of ECS."}
+
 # Visualize proper lognormal versus transformed distributions for ECS
-tibble(lognorm = ecs_vals_lognorm, norm = runlist$ECS) %>% 
+tibble(lognorm = ecs_vals_lognorm, transformed = runlist$ECS) %>% 
   pivot_longer(everything()) %>% 
   ggplot(aes(value, fill = name)) + geom_density(alpha = 0.5) +
   ggtitle("Comparison of (proper) lognormal with transformed distribution for ECS")
 
-# Name and units of parameters
-name_vector <- c("BETA" = BETA(), "Q10_RH" = Q10_RH(), 
-                 "ECS" = ECS(), "NPP_FLUX0" = NPP_FLUX0(),
-                 "AERO_SCALE" = AERO_SCALE(), "DIFFUSIVITY" = DIFFUSIVITY()
-                 )
-
-units_vector <- c("BETA" = "(unitless)", "Q10_RH" = "(unitless)", 
-                  "ECS" = "degC", "NPP_FLUX0" = "Pg C/yr",
-                  "AERO_SCALE" = "(unitless)", "DIFFUSIVITY" = "cm2/s"
-                  )
 ```
 
 ## Run the model
@@ -226,7 +240,7 @@ run_hector <- function(pdata, c) {
     message(" ", p, appendLF = FALSE)
     setvar(c, NA, do.call(p, list()), pdata[p][[1]], units_vector[p])
   }
-  message(" ...running")
+  message("  ")
   # Set a tracking date, reset and run core
   setvar(c, NA, TRACKING_DATE(), 1950, NA)
   reset(c)
@@ -332,7 +346,7 @@ runlist %>%
 
 ## Hector temperature vs. CMIP6 
 
-``` {r cmip, fig.cap = " Global temperature anomaly from CMIP6 and filtered Hector runs. Lines show median; shaded areas show ±1 s.d. of median (darker) and minimum and maximum of ensemble (lighter)."}
+``` {r cmip, fig.cap = " Visualization of sample model runs. The red dots represent the CMIP6 minimums and maximums for global temperature anomaly, and the runs that pass must fall within these bounds more than 50% of the time."}
 # Read in CMIP6 comparison data
 cmip <- read.csv("CMIP6_annual_tas_global.csv") %>%
   filter(variable == "Tgav",
@@ -371,14 +385,18 @@ hector_temp %>%
   ggplot(aes(year, value, color = fraction_fail, group = run_number)) + 
   geom_line() + 
   geom_point(aes(y = minimum), color = "red") + 
-  geom_point(aes(y = maximum), color = "red")
+  geom_point(aes(y = maximum), color = "red") +
+  labs(x = "Year",
+       y = expression(degree*C))
 
+```
+
+``` {r filtered, fig.cap = "Global temperature anomaly from CMIP6 and filtered Hector runs. Lines show median; shaded areas show ±1 s.d. of median (darker) and minimum and maximum of ensemble (lighter)."}
 # Filter out 'unrealistic' runs (identified above)
-model_output %>%
+model_output_filtered <- model_output %>%
   left_join(run_fail_summary, by = "run_number") %>% 
-  filter(fraction_fail < 0.5) ->
-  model_output_filtered
-
+  filter(fraction_fail < 0.5)
+  
 # Plot temperature spreads for the filtered runs
 model_output_filtered %>%
   filter(variable == "Tgav",

--- a/trackingC.Rmd
+++ b/trackingC.Rmd
@@ -386,6 +386,7 @@ hector_temp %>%
   geom_line() + 
   geom_point(aes(y = minimum), color = "red") + 
   geom_point(aes(y = maximum), color = "red") +
+  scale_color_viridis_c() +
   labs(x = "Year",
        y = expression(degree*C))
 

--- a/trackingC.Rmd
+++ b/trackingC.Rmd
@@ -206,6 +206,7 @@ units_vector <- c("BETA" = "(unitless)", "Q10_RH" = "(unitless)",
 ```
 
 ## Run the model
+
 Run the model and store outputs and tracking data.
 
 ```{r functions, cache=TRUE, message=FALSE}

--- a/trackingC.Rmd
+++ b/trackingC.Rmd
@@ -397,6 +397,11 @@ hector_temp %>%
 model_output_filtered <- model_output %>%
   left_join(run_fail_summary, by = "run_number") %>% 
   filter(fraction_fail < 0.5)
+
+# Note that the tracking output needs to be filtered as well
+good_runs <- unique(model_output_filtered$run_number)
+trk_output_filtered <- trk_output %>%
+  filter(run_number %in% good_runs)
   
 # Plot temperature spreads for the filtered runs
 model_output_filtered %>%
@@ -427,7 +432,7 @@ model_output_filtered %>%
 
 ``` {r atmosphere-by-source, fig.cap = " Fraction of CO2 in the atmosphere by source pool from 100 random runs. Dark line shows the median."}
 # Isolate the atmosphere pool to better understand its composition 
-atmosphere_pool <- trk_output %>%
+atmosphere_pool <- trk_output_filtered %>%
   filter(pool_name == "atmos_c")
 
 # This plot looks at source fraction by source pool in the atmosphere and the median run.
@@ -513,7 +518,7 @@ ggpairs(ffi_atm_2100,
 # Step 1: compute source_quantity = pool_value * source_fraction
 # Step 2: for each year and source_name, compute destination_fraction
 
-ffi_destinations <- trk_output %>%
+ffi_destinations <- trk_output_filtered %>%
   filter(source_name == "earth_c", pool_name != "earth_c") %>%
   mutate(source_quantity = pool_value * source_fraction) %>%
   group_by(year, run_number) %>%
@@ -524,8 +529,7 @@ ffi_destinations <- trk_output %>%
 dest_runs <- slice_sample(ffi_destinations, n = 16)
 dest_plot <- filter(ffi_destinations, run_number %in% dest_runs$run_number)
 
-ggplot(dest_plot, aes(year, destination_fraction, 
-                   fill = pool_name)) +
+ggplot(dest_plot, aes(year, destination_fraction, fill = pool_name)) +
   geom_area() +
   scale_fill_viridis_d() +
   facet_wrap(~run_number) +
@@ -583,7 +587,7 @@ ggplot(relimp_out, aes(year, value, fill = param)) +
 
 ```{r af-windows, fig.cap = " Airborne fraction computed over varying time windows."}
 # Prep the data
-atm_earth_diffs <- trk_output %>%
+atm_earth_diffs <- trk_output_filtered %>%
   # Isolate atmosphere and earth total pool values
   filter(pool_name %in% c("atmos_c", "earth_c")) %>% 
   group_by(run_number, year, pool_name) %>% 
@@ -633,7 +637,7 @@ af_results %>%
 # Compute cumulative emissions over time
 # We use the change in earth_c to compute emissions; note this will not work
 # if ever using a scenario with fossil fuel sequestration (atmosphere -> earth)
-emissions <- trk_output %>%
+emissions <- trk_output_filtered %>%
   filter(pool_name == "earth_c",
          source_name == "earth_c",
          run_number == min(run_number)) %>%
@@ -646,7 +650,7 @@ emissions <- trk_output %>%
   select(year, cumulative_emissions)
   
 # Compute the fraction of fossil fuel emissions residing in the atmosphere
-emissions_fraction <- trk_output %>%
+emissions_fraction <- trk_output_filtered %>%
   filter(pool_name == "atmos_c", 
          source_name == "earth_c") %>%
   # How much earth_c is in atmos_c? 

--- a/trackingC.Rmd
+++ b/trackingC.Rmd
@@ -141,7 +141,7 @@ lognorm <- function(m, sd){
 runlist <- tibble(
   run_number = 1:N_RUNS,
   # Keenan et al. (2021)
-  "BETA" = rnorm(N_RUNS, mean = 0.54, sd = 0.03),
+  "BETA" = rnorm(N_RUNS, mean = 0.5, sd = 0.1),
   # Davidson and Janssens (2006)
   "Q10_RH" = rlnorm(N_RUNS, lognorm(2, 1.0)[1], lognorm(2, 1.0)[2]),
   # Ito (2011)

--- a/trackingC.Rmd
+++ b/trackingC.Rmd
@@ -153,21 +153,21 @@ runlist <- tibble(
 # ECS (equilibrium climate sensitivity) and ocean heat diffusivity are 
 # notably correlated with each other, so use a joint PDF for these
 
-# ECS should be log-normally distributed, but a N(3, 1) produces a curve
+# ECS should be log-normally distributed, but N(3, 1) produces a curve
 # that's pretty close if we toss out all values <= 0 (about 0.3%)
 # If we do this, we can use MASS::mvrnorm() which saves us a LOT of work
 # writing a custom rejection sampling routine...
 ecs_vals_lognorm <- rlnorm(N_RUNS, lognorm(3, 1.0)[1], lognorm(3, 1.0)[2])
 ecs_vals <- rnorm(N_RUNS, mean = 3, sd = 1) # see note above
-diff_vals <- rnorm(N_RUNS, mean = 2.3, sd = 0.23)
+diffusion_vals <- rnorm(N_RUNS, mean = 2.3, sd = 0.23)
 
 DESIRED_PCOR <- -0.75  # ECS and diffusivity should be negatively correlated
 # https://en.wikipedia.org/wiki/Covariance_and_correlation
-desired_cov <- DESIRED_PCOR * sd(ecs_vals) * sd(diff_vals)
+desired_cov <- DESIRED_PCOR * sd(ecs_vals) * sd(diffusion_vals)
 # Set up the variance-covariance matrix
 Sigma <- matrix(c(var(ecs_vals), 
                   desired_cov, desired_cov, 
-                  var(diff_vals)),
+                  var(diffusion_vals)),
                 2, 2)
 # ...and generate values--twice as many as needed because we toss out
 # negative ECS values below (see note above)
@@ -181,13 +181,13 @@ jv %>%
   bind_cols(runlist, .) ->
   runlist
 
-# Visualize proper lognormal versus normal distributions for ECS
+# Visualize the final joint distribution of ECS and DIFFUSIVITY
 p <- ggplot(runlist, aes(ECS, DIFFUSIVITY)) + 
   geom_point(alpha = 0.2) + 
   geom_density_2d() +
   ggtitle("Joint distribution of ECS and DIFFUSIVITY")
 ggExtra::ggMarginal(p, type = "histogram", alpha = 0.2)
-# Visualize the final joint distribution of ECS and DIFFUSIVITY
+# Visualize proper lognormal versus normal distributions for ECS
 tibble(lognorm = ecs_vals_lognorm, norm = runlist$ECS) %>% 
   pivot_longer(everything()) %>% 
   ggplot(aes(value, fill = name)) + geom_density(alpha = 0.5) +

--- a/trackingC.Rmd
+++ b/trackingC.Rmd
@@ -171,7 +171,7 @@ Sigma <- matrix(c(var(ecs_vals),
                 2, 2)
 # ...and generate values--twice as many as needed because we toss out
 # negative ECS values below (see note above)
-joint_vals <- MASS::mvrnorm(n = N_RUNS * 2, c(mean(ecs_vals), mean(diff_vals)), Sigma)
+joint_vals <- MASS::mvrnorm(n = N_RUNS * 2, c(mean(ecs_vals), mean(diffusion_vals)), Sigma)
 jv <- as_tibble(joint_vals)
 colnames(jv) <- c("ECS", "DIFFUSIVITY")
 # Filter and bind to the runlist
@@ -217,10 +217,12 @@ run_hector <- function(pdata, c) {
   # c is a Hector newcore environment
   
   # For each parameter within each run, set its value and units
+    message("\tSetting", appendLF = FALSE)
   for(p in colnames(pdata)) {
-    message("\tSetting ", p)
+    message(" ", p, appendLF = FALSE)
     setvar(c, NA, do.call(p, list()), pdata[p][[1]], units_vector[p])
   }
+  message(" ...running")
   # Set a tracking date, reset and run core
   setvar(c, NA, TRACKING_DATE(), 1950, NA)
   reset(c)
@@ -258,6 +260,9 @@ for(row in seq_len(nrow(runlist))) {
 
 # Compute difference in time between start and after loop is run
 tm <- difftime(Sys.time(), start_time, units = "secs") %>% round(1)
+
+# Collapse errors into a single vector
+errors <- unlist(errors)
 ```
 
 Doing `r N_RUNS` runs took `r tm` seconds or `r tm/N_RUNS` s/job.
@@ -301,6 +306,7 @@ max_display <- slice_sample(runlist, n = 100)
 trk_output_slice <- filter(trk_output, run_number %in% max_display$run_number)
 model_output_slice <- filter(model_output, run_number %in% max_display$run_number)
 ```
+
 
 # Results
 

--- a/trackingC.Rmd
+++ b/trackingC.Rmd
@@ -179,8 +179,8 @@ jv <- as_tibble(joint_vals)
 colnames(jv) <- c("ECS", "DIFFUSIVITY")
 # Filter and bind to the runlist
 jv %>% 
-  filter(ECS > 0) %>% 
   mutate(ECS = exp(ECS)) %>%
+  filter(ECS > 0) %>% 
   sample_n(N_RUNS) %>%
   bind_cols(runlist, .) ->
   runlist
@@ -373,7 +373,9 @@ hector_temp <- model_output %>%
 
 # Check if Hector outputs are within CMIP6 range
 for(n in seq_len(nrow(hector_temp))){
-  if(hector_temp$hmin[n] < hector_temp$minimum[n] | hector_temp$hmax[n] > hector_temp$maximum[n]) hector_temp$fail[n] <- "yes" else hector_temp$fail[n] <- "no"
+  if(hector_temp$hmin[n] < hector_temp$minimum[n] | 
+     hector_temp$hmax[n] > hector_temp$maximum[n]) hector_temp$fail[n] <- "yes" 
+  else hector_temp$fail[n] <- "no"
 }
 
 # Filter for more than 50% "yes"

--- a/trackingC.Rmd
+++ b/trackingC.Rmd
@@ -95,6 +95,7 @@ library(dplyr)
 library(tidyr)
 library(ggplot2)
 library(gridExtra)
+library(ggExtra)
 library(GGally)
 library(bookdown)
 
@@ -103,6 +104,14 @@ theme_set(theme_light())
 # Read in ini file, initiate new core
 ssp245 <- system.file("input/hector_ssp245.ini", package = "hector") 
 core <- newcore(ssp245)
+
+# Number of model runs to perform
+N_RUNS <- 1000
+# We use GitHub Actions to make sure this RMarkdown knits successfully
+# But if running there, only do a small number of Hector simulations
+if(Sys.getenv("CI") == "true") {
+  N_RUNS <- 100
+}
 
 # Set range of years for output data
 OUTPUT_YEARS <- 1950:2200
@@ -114,7 +123,7 @@ set.seed(10)
 ### Create runlist of parameter draws
 
 Currently, we are looking at six Hector parameters: `BETA(), Q10_RH(), ECS(),
-NPP_FLUX0(), AERO_SCALE(), DIFFUSIVITY()`. We created a runlist with 1000 random
+NPP_FLUX0(), AERO_SCALE(), DIFFUSIVITY()`. We created a runlist with `r N_RUNS` random
 draws in a normal (or lognormal, where applicable) distribution.
 
 ```{r params}
@@ -126,14 +135,6 @@ lognorm <- function(m, sd){
   mn <- log(m^2 / sqrt(sd^2 + m^2))
   stdev <- sqrt(log(1 + (sd^2 / m^2)))
   v <- c(mn, stdev)
-}
-
-N_RUNS <- 1000
-
-# We use GitHub Actions to make sure this RMarkdown knits successfully
-# But if running there, only do a small number of Hector simulations
-if(Sys.getenv("CI") == "true") {
-  N_RUNS <- 100
 }
 
 # Runlist contains run number, parameter, and a random distribution
@@ -152,15 +153,15 @@ runlist <- tibble(
 # ECS (equilibrium climate sensitivity) and ocean heat diffusivity are 
 # notably correlated with each other, so use a joint PDF for these
 
-# ECS should be log-normally distributed, but a N(3, 2) produces a curve
-# that's pretty close if we toss out all values <= 0 (about 12%)
+# ECS should be log-normally distributed, but a N(3, 1) produces a curve
+# that's pretty close if we toss out all values <= 0 (about 0.3%)
 # If we do this, we can use MASS::mvrnorm() which saves us a LOT of work
 # writing a custom rejection sampling routine...
-#ecs_vals <- rlnorm(N_RUNS, lognorm(3, 1.0)[1], lognorm(3, 1.0)[2])
-ecs_vals <- rnorm(N_RUNS, mean = 3, sd = 2) # see note above
+ecs_vals_lognorm <- rlnorm(N_RUNS, lognorm(3, 1.0)[1], lognorm(3, 1.0)[2])
+ecs_vals <- rnorm(N_RUNS, mean = 3, sd = 1) # see note above
 diff_vals <- rnorm(N_RUNS, mean = 2.3, sd = 0.23)
 
-DESIRED_PCOR <- -0.8  # ECS and diffusivity should be negatively correlated
+DESIRED_PCOR <- -0.75  # ECS and diffusivity should be negatively correlated
 # https://en.wikipedia.org/wiki/Covariance_and_correlation
 desired_cov <- DESIRED_PCOR * sd(ecs_vals) * sd(diff_vals)
 # Set up the variance-covariance matrix
@@ -179,6 +180,18 @@ jv %>%
   sample_n(N_RUNS) %>% 
   bind_cols(runlist, .) ->
   runlist
+
+# Visualize proper lognormal versus normal distributions for ECS
+p <- ggplot(runlist, aes(ECS, DIFFUSIVITY)) + 
+  geom_point(alpha = 0.2) + 
+  geom_density_2d() +
+  ggtitle("Joint distribution of ECS and DIFFUSIVITY")
+ggExtra::ggMarginal(p, type = "histogram", alpha = 0.2)
+# Visualize the final joint distribution of ECS and DIFFUSIVITY
+tibble(lognorm = ecs_vals_lognorm, norm = runlist$ECS) %>% 
+  pivot_longer(everything()) %>% 
+  ggplot(aes(value, fill = name)) + geom_density(alpha = 0.5) +
+  ggtitle("Comparison of (proper) lognormal with normal for ECS")
 
 # Name and units of parameters
 name_vector <- c("BETA" = BETA(), "Q10_RH" = Q10_RH(), 
@@ -248,7 +261,11 @@ tm <- difftime(Sys.time(), start_time, units = "secs") %>% round(1)
 
 Doing `r N_RUNS` runs took `r tm` seconds or `r tm/N_RUNS` s/job.
 
+`r length(errors)` runs had errors.
+
+
 ## Process data
+
 Get lists from above into nice dataframes.
 
 ``` {r data}


### PR DESCRIPTION
Hello @leeyap -

In #29 we discussed and worked through an example of using [rejection sampling](https://en.wikipedia.org/wiki/Rejection_sampling) to produce a joint PDF for two variables.

After our discussion yesterday, I did some more research and discovered the MASS package's [mvrnorm](https://rdrr.io/cran/MASS/man/mvrnorm.html) function, that "produces one or more samples from the specified multivariate normal distribution". This seemed promising! See the examples--basically you only need to specify the µ (means) of the variables and their variance-covariance matrix.

The catch is that `mvrnorm` only works with _normal_ variables, and one of the ones we want to work with (ECS) is log lognormally distributed. Even so, though, this seemed worth trying.

This PR:
* Makes a normal approximation for the ECS lognormal one. It's not perfect, but pretty good (see Rmarkdown)
* Uses `mvrnorm` to produce `N_RUNS` samples of ECS and diffusivity and visualizes their joint distribution
* We do now get a ~fair~ single number of Hector errors (~144~ 1 runs out of 1000), presumably due to some bad combinations of parameters. We can investigate and tweak
* Changes the BETA distribution. I think having that be N(0.54, 0.03) is way too narrow — yes, that was Trevor et al.'s number, but that's just one study and  such a tight uncertainty seems unrealistic

We can discuss!

![download](https://user-images.githubusercontent.com/1956468/164429596-542fbac1-9c35-4c23-8c7d-bb60fc74355d.png)

