### PR TITLE
Implement LUC scalar

### DIFF
--- a/trackingC.Rmd
+++ b/trackingC.Rmd
@@ -30,7 +30,7 @@ library(gridExtra)
 library(ggExtra)
 library(GGally)
 library(bookdown)
-library(data.table) # for fread()
+library(data.table)
 
 theme_set(theme_light())
 

--- a/trackingC.Rmd
+++ b/trackingC.Rmd
@@ -469,7 +469,7 @@ ggplot(plot_data, aes(x = year, fill = def)) +
 
 ## Turning on tracking at different dates
 
-```{r tracking-multiple-years, fig.cap = " Amount of CO2 in the atmosphere sourced from human emissions. Note that turning on tracking in different years does not have a dramatic effect on the composition of the atmosphere pool."}
+```{r tracking-multiple-years, warning = FALSE, fig.cap = " Amount of CO2 in the atmosphere sourced from human emissions. Note that turning on tracking in different years does not have a dramatic effect on the composition of the atmosphere pool."}
 # Prep
 tcore <- reset(core)
 dates <- seq(from = 1750, to = 2250, 50)

--- a/trackingC.Rmd
+++ b/trackingC.Rmd
@@ -49,16 +49,6 @@ max_display <- slice_sample(runlist, n = 100)
 trk_output_slice <- filter(trk_output, run_number %in% max_display$run_number)
 model_output_slice <- filter(model_output, run_number %in% max_display$run_number)
 
-# Name and units of all parameters
-name_vector <- c("BETA" = BETA(), "Q10_RH" = Q10_RH(), 
-                 "ECS" = ECS(), "NPP_FLUX0" = NPP_FLUX0(),
-                 "AERO_SCALE" = AERO_SCALE(), "DIFFUSIVITY" = DIFFUSIVITY()
-                 )
-
-units_vector <- c("BETA" = "(unitless)", "Q10_RH" = "(unitless)", 
-                  "ECS" = "degC", "NPP_FLUX0" = "Pg C/yr",
-                  "AERO_SCALE" = "(unitless)", "DIFFUSIVITY" = "cm2/s"
-                  )
 
 ```
 

--- a/trackingC_common.R
+++ b/trackingC_common.R
@@ -35,4 +35,4 @@ units_vector <- c("BETA" = "(unitless)", "Q10_RH" = "(unitless)",
                   "LUC_SCALAR" = "(unitless)"
 )
 
-scalar <- "LUC_SCALAR"
+scalar_vector <- "LUC_SCALAR"

--- a/trackingC_common.R
+++ b/trackingC_common.R
@@ -5,6 +5,11 @@
 ssp245 <- system.file("input/hector_ssp245.ini", package = "hector") 
 core <- newcore(ssp245)
 
+# Extract LUC emissions data
+run(core)
+luc <- fetchvars(core, core$strtdate:core$enddate, LUC_EMISSIONS())
+
+
 # Number of model runs to perform
 N_RUNS <- 1000
 
@@ -16,3 +21,18 @@ if(Sys.getenv("CI") == "true") {
 
 # Set range of years for output data
 OUTPUT_YEARS <- 1950:2200
+
+# Define name and units of all parameters
+name_vector <- c("BETA" = BETA(), "Q10_RH" = Q10_RH(), 
+                 "ECS" = ECS(), "NPP_FLUX0" = NPP_FLUX0(),
+                 "AERO_SCALE" = AERO_SCALE(), "DIFFUSIVITY" = DIFFUSIVITY(),
+                 "LUC_SCALAR" = "LUC_SCALAR"
+)
+
+units_vector <- c("BETA" = "(unitless)", "Q10_RH" = "(unitless)", 
+                  "ECS" = "degC", "NPP_FLUX0" = "Pg C/yr",
+                  "AERO_SCALE" = "(unitless)", "DIFFUSIVITY" = "cm2/s",
+                  "LUC_SCALAR" = "(unitless)"
+)
+
+scalar <- "LUC_SCALAR"

--- a/trackingC_common.R
+++ b/trackingC_common.R
@@ -5,7 +5,7 @@
 ssp245 <- system.file("input/hector_ssp245.ini", package = "hector") 
 core <- newcore(ssp245)
 
-# Extract LUC emissions data
+# Extract and LUC emissions data for later multiplication by LUC_SCALAR
 run(core)
 luc <- fetchvars(core, core$strtdate:core$enddate, LUC_EMISSIONS())
 

--- a/trackingC_setup.Rmd
+++ b/trackingC_setup.Rmd
@@ -163,7 +163,7 @@ runlist <- tibble(
   # Or, 0.83 < x < 1.61 
   # The following distribution roughly aligns with the above criteria
   # Using a lognormal distribution because we do not want negative or near-zero values
-  "LUC_SCALAR" = rlnorm(N_RUNS, lognorm(1.25, 0.2)[1], lognorm(1.25, 0.2)[2])
+  "LUC_SCALAR" = rlnorm(N_RUNS, lognorm(1.3, 0.2)[1], lognorm(1.3, 0.2)[2])
 )
 
 
@@ -233,7 +233,9 @@ run_hector <- function(pdata, c) {
     message("\tSetting", appendLF = FALSE)
   for(p in colnames(pdata)) {
     message(" ", p, appendLF = FALSE)
-    if(p == scalar) setvar(c, core$strtdate:core$enddate, LUC_EMISSIONS(), (luc$value * pdata["LUC_SCALAR"][[1]]), "Pg C/yr")
+    # If the parameter is a scaling constant, multiply and set scaled values
+    if(p == scalar) setvar(c, luc$year, LUC_EMISSIONS(), (luc$value * pdata[p][[1]]), "Pg C/yr")
+    # Otherwise, simply set the value of the parameter itself
     else setvar(c, NA, do.call(p, list()), pdata[p][[1]], units_vector[p])
   }
   message("  ")

--- a/trackingC_setup.Rmd
+++ b/trackingC_setup.Rmd
@@ -140,24 +140,31 @@ runlist <- tibble(
   run_number = 1:N_RUNS,
   # Keenan et al. (2021)
   "BETA" = rnorm(N_RUNS, mean = 0.5, sd = 0.1),
+  
   # Davidson and Janssens (2006)
   "Q10_RH" = rlnorm(N_RUNS, lognorm(2, 1.0)[1], lognorm(2, 1.0)[2]),
+  
   # Ito (2011)
   "NPP_FLUX0" = rnorm(N_RUNS, mean = 56.2, sd = 5.62),
+  
   # Hector default
-  "AERO_SCALE" = rnorm(N_RUNS, mean = 1.0, sd = 0.1)
+  "AERO_SCALE" = rnorm(N_RUNS, mean = 1.0, sd = 0.1),
+  
+  # Land use change emissions scaling parameter, to account for uncertainties in values for LUC
+  # Friedlingstein et al 2021 state: 
+  # Cumulative CO2 emissions from land-use changes (ELUC) for 1850-2020 were 200 ± 65 GtC...
+  # ...large spread among individual estimates of 140 GtC (updated H&N2017), 270 GtC (BLUE),
+  # and 195 GtC (OSCAR) for the three bookkeeping models and a similar wide estimate of 190 ± 60 GtC for the DGVMs
+  # Cumulative LUC_EMISSIONS() in Hector from 1850 to 2020 total 168 GtC
+  # We want to create a random distribution to scale our Hector emissions
+  # to account for the large uncertainties
+  # Our bounds for a reasonable scalar therefore are (270/168) and (140/168)
+  # Or, 0.83 < x < 1.61 
+  # The following distribution roughly aligns with the above criteria
+  # Using a lognormal distribution because we do not want negative or near-zero values
+  "LUC_SCALAR" = rlnorm(N_RUNS, lognorm(1.25, 0.2)[1], lognorm(1.25, 0.2)[2])
 )
 
-# Name and units of all parameters
-name_vector <- c("BETA" = BETA(), "Q10_RH" = Q10_RH(), 
-                 "ECS" = ECS(), "NPP_FLUX0" = NPP_FLUX0(),
-                 "AERO_SCALE" = AERO_SCALE(), "DIFFUSIVITY" = DIFFUSIVITY()
-                 )
-
-units_vector <- c("BETA" = "(unitless)", "Q10_RH" = "(unitless)", 
-                  "ECS" = "degC", "NPP_FLUX0" = "Pg C/yr",
-                  "AERO_SCALE" = "(unitless)", "DIFFUSIVITY" = "cm2/s"
-                  )
 
 ```
 
@@ -225,7 +232,8 @@ run_hector <- function(pdata, c) {
     message("\tSetting", appendLF = FALSE)
   for(p in colnames(pdata)) {
     message(" ", p, appendLF = FALSE)
-    setvar(c, NA, do.call(p, list()), pdata[p][[1]], units_vector[p])
+    if(p == scalar) setvar(c, core$strtdate:core$enddate, LUC_EMISSIONS(), (luc$value * pdata["LUC_SCALAR"][[1]]), "Pg C/yr")
+    else setvar(c, NA, do.call(p, list()), pdata[p][[1]], units_vector[p])
   }
   message("  ")
   # Set a tracking date, reset and run core
@@ -235,7 +243,7 @@ run_hector <- function(pdata, c) {
   # Access and save tracking data, model outputs
   out <- list()
   out$tdata <- get_tracking_data(c) %>% filter(year %in% OUTPUT_YEARS)
-  out$results <- fetchvars(c, OUTPUT_YEARS)
+  out$results <- fetchvars(c, OUTPUT_YEARS, c("Ca", "Ftot", "FCO2", "Tgav", "luc_emissions"))
   return(out)
 }
 

--- a/trackingC_setup.Rmd
+++ b/trackingC_setup.Rmd
@@ -234,7 +234,7 @@ run_hector <- function(pdata, c) {
   for(p in colnames(pdata)) {
     message(" ", p, appendLF = FALSE)
     # If the parameter is a scaling constant, multiply and set scaled values
-    if(p == scalar) setvar(c, luc$year, LUC_EMISSIONS(), (luc$value * pdata[p][[1]]), "Pg C/yr")
+    if(p %in% scalar_vector) setvar(c, luc$year, LUC_EMISSIONS(), (luc$value * pdata[p][[1]]), "Pg C/yr")
     # Otherwise, simply set the value of the parameter itself
     else setvar(c, NA, do.call(p, list()), pdata[p][[1]], units_vector[p])
   }

--- a/trackingC_setup.Rmd
+++ b/trackingC_setup.Rmd
@@ -98,6 +98,7 @@ library(gridExtra)
 library(ggExtra)
 library(GGally)
 library(bookdown)
+library(data.table)
 
 theme_set(theme_light())
 
@@ -316,9 +317,9 @@ model_output <- left_join(model_output, runlist, by = "run_number")
 # Save outputs
 
 ``` {r output-files}
-write.csv(runlist, "./output_files/runlist.csv", row.names = FALSE)
-write.csv(model_output, "./output_files/model_output.csv", row.names = FALSE)
-write.csv(trk_output, "./output_files/trk_output.csv", row.names = FALSE)
+fwrite(runlist, "./output_files/runlist.csv", row.names = FALSE)
+fwrite(model_output, "./output_files/model_output.csv", row.names = FALSE)
+fwrite(trk_output, "./output_files/trk_output.csv", row.names = FALSE)
 ```
 
 # The End


### PR DESCRIPTION
Closes #34 

This PR implements a new parameter, a LUC emissions scalar, to account for uncertainties in values for LUC emissions.

Friedlingstein et al 2021 state: 
  - Cumulative CO2 emissions from land-use changes (ELUC) for 1850-2020 were 200 ± 65 GtC...
  - ...large spread among individual estimates of 140 GtC (updated H&N2017), 270 GtC (BLUE), and 195 GtC (OSCAR) for the three bookkeeping models and a similar wide estimate of 190 ± 60 GtC for the DGVMs

Cumulative LUC_EMISSIONS() in Hector from 1850 to 2020 total 168 GtC. We want to create a random distribution to scale our Hector emissions to account for the large uncertainties. Our bounds for a reasonable scalar therefore are (270/168) and (140/168), or 0.83 < x < 1.61 

A lognormal (no values <=0) with a mean of 1.25 and a standard deviation on 0.25 seems to fall reasonably well within these bounds (not perfectly!). When applied to annual LUC emissions below 2040 (noting that emissions in SSP245 drop off to 0 at 2053, and values start to drop off in about 2040):
```
   Min. 1st Qu.  Median    Mean 3rd Qu.    Max. 
 0.4667  1.1013  1.4792  1.4946  1.8348  4.5078 
```
Might need to tweak this a bit after running a few more times. Runs with <1000 values do not produce the same results.

Anyway, the `run_hector()` function now checks if the `runlist` parameter is included in a `scalar` variable. If yes, it multiplies `luc_emissions` by the scalar (yes, this is hard coded at the moment - do we foresee implementing more parameters like this? If so, I can edit). If not, it carries on as per usual. I also included `luc_emissions` as an output variable, in addition to the four defaults.

Feedback and suggestions welcome 😄 