### PR TITLE
Modify scripts to include all SSPs

### DIFF
--- a/.github/workflows/render-rmarkdown.yaml
+++ b/.github/workflows/render-rmarkdown.yaml
@@ -26,7 +26,7 @@ jobs:
           install.packages(c("rmarkdown", "readr", "dplyr", "tidyr", "remotes"))
           install.packages(c("kableExtra", "relaimpo", "bookdown", "data.table"))
           install.packages(c("ggplot2", "ggExtra", "gridExtra", "GGally"))
-          remotes::install_github("jgcri/hector@land_tracking")
+          remotes::install_github("jgcri/hector@7e337f3")
         shell: Rscript {0}
       - name: Render Rmarkdown files
         run: |

--- a/trackingC.Rmd
+++ b/trackingC.Rmd
@@ -341,7 +341,7 @@ ggplot(dest_plot, aes(year, destination_fraction, fill = pool_name)) +
 ```{r relative-importance, message=FALSE, warning=FALSE, fig.cap = " Relative importance of parameters over time in controlling atmosphere as a destination of fossil fuel and industrial (FFI) emissions."}
 # Filter to just atmosphere pool, and remove unneeded columns
 dest_e2a <- filter(ffi_destinations, pool_name == "atmos_c")
-dest_e2a_minimal <- dest_e2a[c("year", "destination_fraction", names(name_vector))]
+dest_e2a_minimal <- dest_e2a[c("year", "destination_fraction", "ssp", names(name_vector))]
 
 # Function to calculate relative importance of parameters in
 # explaining how much destination_fraction varies for a given
@@ -351,6 +351,8 @@ dest_e2a_minimal <- dest_e2a[c("year", "destination_fraction", names(name_vector
 calc_relimp <- function(x) {
   yr <- x$year[1] # record year...
   x$year <- NULL # and drop year column
+  sce <- x$ssp[1]
+  x$ssp <- NULL
   # Fit model. The formula notation means "destination fraction as a
   # function of all other terms" (which is why we dropped year)
   m <- lm(destination_fraction ~ ., data = x)
@@ -363,12 +365,12 @@ calc_relimp <- function(x) {
     return(NULL)
   }
   # Return a data frame: year, parameter, relative importance
-  tibble(year = yr, param = names(relimp), value = relimp)
+  tibble(ssp = sce, year = yr, param = names(relimp), value = relimp)
   
 }
 
 # Run calc_relimp() above on each year's data
-dest_split <- split(dest_e2a_minimal, dest_e2a_minimal$year)
+dest_split <- split(dest_e2a_minimal, list(dest_e2a_minimal$year, dest_e2a_minimal$ssp))
 relimp_out <- lapply(dest_split, FUN = calc_relimp) %>% 
   bind_rows()
 
@@ -377,6 +379,7 @@ ggplot(relimp_out, aes(year, value, fill = param)) +
   geom_area() +
   coord_cartesian(expand = FALSE) +
   scale_fill_viridis_d(direction = -1) +
+  facet_wrap(~ssp) +
   labs(x = "Year",
        y = expression(Relative~importance~"for"~FFI[atm]))
 ```

--- a/trackingC.Rmd
+++ b/trackingC.Rmd
@@ -316,21 +316,22 @@ ggpairs(ffi_atm_2100,
 # Step 2: for each year and source_name, compute destination_fraction
 
 ffi_destinations <- trk_output_filtered %>%
-  filter(ssp == MAIN_SCENARIO, source_name == "earth_c", pool_name != "earth_c") %>%
+  filter(source_name == "earth_c", pool_name != "earth_c") %>%
   mutate(source_quantity = pool_value * source_fraction) %>%
-  group_by(year, run_number) %>%
+  group_by(year, ssp, run_number) %>%
   mutate(destination_fraction = source_quantity / sum(source_quantity)) %>% 
   ungroup()
 
 # Just looking at 16 random runs
-dest_runs <- slice_sample(ffi_destinations, n = 16)
-dest_plot <- filter(ffi_destinations, run_number %in% dest_runs$run_number)
+dest_runs <- slice_sample(ffi_destinations, n = 10)
+dest_plot <- filter(ffi_destinations, 
+                    run_number %in% dest_runs$run_number & run_number < N_RUNS_SCE)
 
 ggplot(dest_plot, aes(year, destination_fraction, fill = pool_name)) +
   geom_area() +
   scale_fill_viridis_d() +
-  facet_wrap(~run_number) +
-  theme(strip.background = element_blank(), 
+  facet_grid(ssp~run_number) +
+  theme(#strip.background = element_blank(),
         strip.text.x = element_blank(),
         axis.text.x = element_text(angle = 90)) +
   labs(x = "Year",

--- a/trackingC.Rmd
+++ b/trackingC.Rmd
@@ -45,6 +45,7 @@ trk_output <- fread("./output_files/trk_output.csv")
 # individual runs, we use slice_sample() to randomly select 100 rows.
 
 # Pull random run numbers from the runlist and filter output by random runs
+### This is not going to give even numbers across scenarios
 max_display <- slice_sample(runlist, n = 100)
 trk_output_slice <- filter(trk_output, run_number %in% max_display$run_number)
 model_output_slice <- filter(model_output, run_number %in% max_display$run_number)
@@ -58,7 +59,7 @@ in a manuscript.
 
 ## Realized parameter PDFs
 
-``` {r params-PDFs, fig.cap = paste0(" Probability densities of each parameter (N=", N_RUNS_MAIN, " draws).")}
+``` {r params-PDFs, fig.cap = paste0(" Probability densities of each parameter (N=", SSP_runs[[MAIN_SCENARIO]], " draws).")}
 # Density plots to visualize parameter distributions
 runlist %>% 
   filter(ssp == MAIN_SCENARIO) %>%
@@ -121,10 +122,18 @@ run_fail_summary %>%
   knitr::kable()
 
 # ...and a figure 
-hector_temp %>% 
-  left_join(run_fail_summary, by = c("run_number", "ssp")) %>%
-  ### THIS NO LONGER WORKS
-  # filter(run_number <= 100) # this is a debugging figure; plot just 100 runs for clarity
+hector_temp_runs <- hector_temp %>% 
+  group_by(ssp) %>%
+  filter(year == min(year)) %>%
+  slice_sample(n = 100) %>% # this is a debugging figure; plot just 100 runs for clarity
+  arrange(ssp, run_number) %>%
+  summarize(run_number)
+
+# Filter out data for just the 100 rusn per senario identified above
+hector_temp_slice <- left_join(hector_temp_runs, hector_temp, by = c("run_number", "ssp"))
+  
+# Plot
+left_join(hector_temp_slice, run_fail_summary, by = c("run_number", "ssp")) %>%
   ggplot(aes(year, value, color = fraction_fail, group = run_number)) + 
   geom_line() + 
   geom_point(aes(y = minimum), color = "black") + 
@@ -325,11 +334,18 @@ ffi_destinations <- trk_output_filtered %>%
 
 # Just looking at 5 random runs across scenarios
 ### THIS NO LONGER WORKS
-dest_runs <- slice_sample(ffi_destinations, n = 5)
+dest_runs <- ffi_destinations %>%
+  group_by(ssp) %>%
+  filter(year == min(year)) %>%
+  slice_sample(n = 5) %>% 
+  summarize(run_number)
+  
 dest_plot <- filter(ffi_destinations, 
-                    run_number %in% dest_runs$run_number & run_number < N_RUNS_SCE)
+                    run_number %in% dest_runs$run_number) 
 
-ggplot(dest_plot, aes(year, destination_fraction, fill = pool_name)) +
+
+dest_plot %>%
+  ggplot(aes(year, destination_fraction, fill = pool_name)) +
   geom_area() +
   scale_fill_viridis_d() +
   facet_grid(ssp~run_number) +
@@ -444,11 +460,15 @@ af_results %>%
 
 # This function computes annual cumulative earth_c emissions for a given tracking dataset
 ### THIS NO LONGER WORKS
+min_runs <- trk_output_filtered %>%
+  group_by(ssp) %>%
+  summarize(mrun = min(run_number))
+
 calc_emissions <- function(data){
   data %>% 
     filter(pool_name == "earth_c",
          source_name == "earth_c",
-         run_number == min(run_number)) %>%
+         run_number %in% min_runs$mrun) %>%
     arrange(year) %>%
     group_by(ssp) %>%
     # the NA at the end here is so that cumulative emissions 'line up' correctly

--- a/trackingC.Rmd
+++ b/trackingC.Rmd
@@ -60,7 +60,7 @@ in a manuscript.
 
 ## Hector temperature vs. CMIP6 
 
-``` {r filtered, warning = FALSE, fig.cap = "Global temperature anomaly from CMIP6 and filtered Hector runs. Lines show median; shaded areas show ±1 s.d. of median (darker) and minimum and maximum of ensemble (lighter)."}
+``` {r filtered, warning = FALSE, message = FALSE, fig.cap = "Global temperature anomaly from CMIP6 and filtered Hector runs. Lines show median; shaded areas show ±1 s.d. of median (darker) and minimum and maximum of ensemble (lighter)."}
 # Read in CMIP6 comparison data
 cmip_raw <- read.csv("./data_files/CMIP6_annual_tas_global.csv")
 
@@ -209,12 +209,11 @@ atmosphere_pool <- trk_output_filtered %>%
   filter(pool_name == "atmos_c")
 
 # Create facet labels
-### FIX THIS
-var_labels_s <- c("atmos_c", "deep", "detritus_c", "earth_c", "HL", "intermediate",
-                               "LL", "soil_c", "veg_c")
-names(var_labels_s) <- c("Atmosphere", "Deep ocean", "Detritus", "Anthropogenic emissions",
+pool_labels <- c("Atmosphere", "Deep ocean", "Detritus", "Anthropogenic emissions",
                                "High-lat ocean", "Intermed. ocean",
                                "Low-lat ocean", "Soil", "Vegetation")
+names(pool_labels) <- c("atmos_c", "deep", "detritus_c", "earth_c", "HL", "intermediate",
+                               "LL", "soil_c", "veg_c")
 
 # This plot looks at source fraction by source pool in the atmosphere and the median run.
 atmosphere_pool %>%
@@ -224,7 +223,7 @@ atmosphere_pool %>%
              color = as.factor(run_number), group = run_number)) +
   geom_line(size = 0.5, show.legend = FALSE) +
   facet_wrap(~source_name, scales = "free",
-             labeller = labeller(source_name = var_labels_s)) +
+             labeller = labeller(source_name = pool_labels)) +
   labs(x = "Year",
        y = "Source fraction") +
   scale_color_grey(start = 0.7, end = 0.7) +
@@ -276,18 +275,17 @@ ffi_destinations <- trk_output_filtered %>%
   ungroup()
 
 # Just looking at 5 random runs across scenarios
-### THIS NO LONGER WORKS
-dest_runs <- ffi_destinations %>%
-  group_by(ssp) %>%
-  filter(year == min(year)) %>%
-  slice_sample(n = 5) %>%
-  summarize(run_number)
+# dest_runs <- ffi_destinations %>%
+#   group_by(ssp) %>%
+#   filter(year == min(year)) %>%
+#   slice_sample(n = 5) %>%
+#   summarize(run_number)
 
-dest_plot <- filter(ffi_destinations, 
-                    run_number %in% dest_runs$run_number) 
+# dest_plot <- filter(ffi_destinations, 
+#                     run_number %in% dest_runs$run_number) 
 
 # Just looking at the mean of all runs in SSP245
-dest_plot %>%
+ffi_destinations %>%
   filter(ssp == MAIN_SCENARIO) %>%
   group_by(ssp, year, pool_name) %>%
   mutate(dest_avg = mean(destination_fraction)) %>%
@@ -557,19 +555,25 @@ ggplot(plot_data, aes(x = year, fill = def)) +
 
 ``` {r s-params-PDFs, fig.cap = paste0(" Probability densities of each parameter (N=", SSP_runs[[MAIN_SCENARIO]], " draws).")}
 # Density plots to visualize parameter distributions
+param_labels <- c("Aerosol forcing", "CO2 fertilization", "Ocean diffusivity", 
+                  "ECS", "LUC emissions", "Pre-industrial NPP", "Q10")
+names(param_labels) <- c("AERO_SCALE", "BETA", "DIFFUSIVITY", "ECS", "LUC_SCALE", 
+                         "NPP_FLUX0", "Q10_RH")
+
 runlist %>% 
   filter(ssp == MAIN_SCENARIO) %>%
   select(-c(run_number, ssp)) %>%
   pivot_longer(everything()) %>% 
   ggplot(aes(value)) +
   geom_density() + 
-  facet_wrap(~name, scales = "free") +
+  facet_wrap(~name, scales = "free",
+             labeller = labeller(name = param_labels)) +
   labs(x = NULL, y = NULL)
 ```
 
 ## Hector temperature vs CMIP6 diagnostic
 
-``` {r s-cmip, message = FALSE, fig.cap = " Visualization of sample model runs. The black dots represent the CMIP6 minimums and maximums for global temperature anomaly, and the runs that pass must fall within these bounds more than 50% of the time."}
+``` {r s-cmip, message = FALSE, warning = FALSE, fig.cap = " Visualization of sample model runs. The black dots represent the CMIP6 minimums and maximums for global temperature anomaly, and the runs that pass must fall within these bounds more than 50% of the time."}
 # Visualize the run fail summary calculated above
 # Make a table of failure rates
 run_fail_summary %>% 
@@ -605,7 +609,7 @@ left_join(hector_temp_slice, run_fail_summary, by = c("run_number", "ssp")) %>%
 
 ## Source coefficients of variability
 
-``` {r s-coeff-var, fig.cap = " Coefficients of variability for each source in the atmosphere over time."}
+``` {r s-coeff-var, warning = FALSE, fig.cap = " Coefficients of variability for each source in the atmosphere over time."}
 # Compute coefficient of variability for each source in the atmosphere pool
 atmos_cv <- atmosphere_pool %>%
   filter(ssp == MAIN_SCENARIO) %>%
@@ -647,7 +651,8 @@ ggpairs(ffi_atm_2100,
         aes(color = sf), 
         diag = list(mapping = aes(alpha = 0.5)),
         upper = list(continuous = "blank"),
-        legend = c(6,5)) + 
+        legend = c(6,5),
+        #columnLabels = param_labels) + 
   scale_color_viridis_d() + 
   scale_fill_viridis_d() +
   labs(color = "Source Fraction")
@@ -668,13 +673,13 @@ af_results %>%
   scale_color_viridis_c() +
   labs(x = "Year",
        y = "Airborne fraction",
-       color = "Window size") 
+       color = "Window size")
 
 ```
 
 ## Tracking year plus one (work in progress)
 
-``` {r s-tracking-af}
+``` {r s-tracking-af, echo = FALSE, eval = FALSE}
 # We want to calculate airborne fraction in the year immediately following the 
 # tracking date. 
 date_plus_one <- dates + 1

--- a/trackingC.Rmd
+++ b/trackingC.Rmd
@@ -41,15 +41,6 @@ runlist <- fread("./output_files/runlist.csv")
 model_output <- fread("./output_files/model_output.csv")
 trk_output <- fread("./output_files/trk_output.csv")
 
-# If there are over 100 observations per time point and we want to plot
-# individual runs, we use slice_sample() to randomly select 100 rows.
-
-# Pull random run numbers from the runlist and filter output by random runs
-### This is not going to give even numbers across scenarios
-max_display <- slice_sample(runlist, n = 100)
-trk_output_slice <- filter(trk_output, run_number %in% max_display$run_number)
-model_output_slice <- filter(model_output, run_number %in% max_display$run_number)
-
 ```
 
 # Results
@@ -243,6 +234,10 @@ atmosphere_pool <- trk_output_filtered %>%
          pool_name == "atmos_c")
 
 # This plot looks at source fraction by source pool in the atmosphere and the median run.
+max_display <- runlist %>%
+  filter(ssp == MAIN_SCENARIO) %>%
+  slice_sample(n = 100)
+
 atmosphere_pool %>%
   filter(run_number %in% max_display$run_number) %>%
   ggplot(aes(year, source_fraction, 

--- a/trackingC.Rmd
+++ b/trackingC.Rmd
@@ -56,130 +56,7 @@ model_output_slice <- filter(model_output, run_number %in% max_display$run_numbe
 The following sections contain tentative figures in the order they would appear
 in a manuscript. 
 
-## Realized parameter PDFs
-
-``` {r params-PDFs, fig.cap = paste0(" Probability densities of each parameter (N=", SSP_runs[[MAIN_SCENARIO]], " draws).")}
-# Density plots to visualize parameter distributions
-runlist %>% 
-  filter(ssp == MAIN_SCENARIO) %>%
-  select(-c(run_number, ssp)) %>%
-  pivot_longer(everything()) %>% 
-  ggplot(aes(value)) +
-  geom_density() + 
-  facet_wrap(~name, scales = "free") +
-  labs(x = NULL, y = NULL)
-```
-
-## Hector temperature vs. CMIP6 
-
-``` {r cmip, message = FALSE, fig.cap = " Visualization of sample model runs. The black dots represent the CMIP6 minimums and maximums for global temperature anomaly, and the runs that pass must fall within these bounds more than 50% of the time."}
-# Read in CMIP6 comparison data
-cmip_raw <- read.csv("./data_files/CMIP6_annual_tas_global.csv")
-
-# Isolate desired scenarios
-cmip_sce <- list()
-for(n in names(SSP_files)){
-  cmip_sce[[n]] <- cmip_raw %>% 
-    filter(experiment == n)
-}  
-cmip_sce <- bind_rows(cmip_sce) 
-
-# Filter for Tgav and calculate summary metrics
-cmip_scenarios <- cmip_sce %>%
-  rename(ssp = experiment) %>%
-  filter(variable == "Tgav",
-         year <= 2100) %>%
-  group_by(year, ssp) %>%
-  summarize(sdev = sd(value),
-            minimum = min(value),
-            maximum = max(value),
-            med = median(value)) %>%
-  mutate(source = "CMIP6") %>%
-  arrange(ssp, year)
-
-# Identify unrealistic runs - for each run, if more than 50% of values are
-# outside of the min/max of the CMIP data, the run is nixed
-cmip_bounds <- cmip_scenarios %>% 
-  group_by(ssp) %>%
-  select(year, minimum, maximum)
-
-hector_temp <- model_output %>%
-  filter(variable == "Tgav",
-         year >= 2015 & year <= 2100) %>%
-  select(run_number, ssp, year, value) %>%
-  left_join(cmip_bounds, by = c("year", "ssp")) %>% 
-  mutate(fail = value < minimum | value > maximum)
-
-run_fail_summary <- hector_temp %>%
-  group_by(ssp, run_number) %>%
-  summarise(fraction_fail = sum(fail) / n())
-
-# Make a table of failure rates
-run_fail_summary %>% 
-  group_by(fraction_fail > 0.5) %>% 
-  summarise(n()) %>% 
-  knitr::kable()
-
-# ...and a figure 
-hector_temp_runs <- hector_temp %>% 
-  group_by(ssp) %>%
-  filter(year == min(year)) %>%
-  slice_sample(n = 100) %>% # this is a debugging figure; plot just 100 runs for clarity
-  arrange(ssp, run_number) %>%
-  summarize(run_number)
-
-# Filter out data for just the 100 rusn per senario identified above
-hector_temp_slice <- left_join(hector_temp_runs, hector_temp, by = c("run_number", "ssp"))
-  
-# Plot
-left_join(hector_temp_slice, run_fail_summary, by = c("run_number", "ssp")) %>%
-  ggplot(aes(year, value, color = fraction_fail, group = run_number)) + 
-  geom_line() + 
-  geom_point(aes(y = minimum), color = "black") + 
-  geom_point(aes(y = maximum), color = "black") +
-  facet_wrap(~ssp) +
-  scale_color_viridis_c() +
-  labs(x = "Year",
-       y = expression(degree*C))
-
-```
-
-``` {r filtered, fig.cap = "Global temperature anomaly from CMIP6 and filtered Hector runs. Lines show median; shaded areas show ±1 s.d. of median (darker) and minimum and maximum of ensemble (lighter)."}
-# Filter out 'unrealistic' runs (identified above)
-model_output_filtered <- model_output %>%
-  left_join(run_fail_summary, by = c("ssp", "run_number")) %>% 
-  filter(fraction_fail < 0.5)
-
-# Note that the tracking output needs to be filtered as well
-trk_output_filtered <- trk_output %>%
-  left_join(run_fail_summary, by = c("ssp", "run_number")) %>% 
-  filter(fraction_fail < 0.5)
-  
-# Plot temperature spreads for the filtered runs
-model_output_filtered %>%
-  filter(variable == "Tgav",
-         year >= 2015 & year <= 2100) %>% 
-  # compute median, min, max, etc. for all remaining runs
-  group_by(year, ssp) %>%
-  summarize(sdev = sd(value),
-            minimum = min(value),
-            maximum = max(value),
-            med = median(value), .groups = "drop") %>% 
-  # combine with CMIP6 data
-  mutate(source = "Hector") %>% 
-  bind_rows(cmip_scenarios) %>%
-  # ...and plot
-  ggplot(aes(year, fill = source, color = source)) +
-  geom_ribbon(aes(ymin = minimum, ymax = maximum), alpha = 0.15, color = NA) +
-  geom_ribbon(aes(ymin = med - sdev, ymax = med + sdev), alpha = 0.5, color = NA) +
-  geom_line(aes(y = med), size = 2) +
-  scale_color_viridis_d(begin = 0.5) +
-  scale_fill_viridis_d(begin = 0.5) +
-  facet_wrap(~ssp, scales = "free") +
-  theme(legend.title = element_blank()) +
-  labs(x = "Year",
-       y = expression(degree*C))
-```
+# Primary figures
 
 ## Hector atmospheric CO~2~ vs observed data
 
@@ -230,7 +107,45 @@ plot_data_co2 %>%
   labs(x = "Year",
        y = "CO2 (ppm)")
 
+```
 
+## Hector temperature vs. CMIP6 
+
+``` {r filtered, fig.cap = "Global temperature anomaly from CMIP6 and filtered Hector runs. Lines show median; shaded areas show ±1 s.d. of median (darker) and minimum and maximum of ensemble (lighter)."}
+# Filter out 'unrealistic' runs (identified above)
+model_output_filtered <- model_output %>%
+  left_join(run_fail_summary, by = c("ssp", "run_number")) %>% 
+  filter(fraction_fail < 0.5)
+
+# Note that the tracking output needs to be filtered as well
+trk_output_filtered <- trk_output %>%
+  left_join(run_fail_summary, by = c("ssp", "run_number")) %>% 
+  filter(fraction_fail < 0.5)
+  
+# Plot temperature spreads for the filtered runs
+model_output_filtered %>%
+  filter(variable == "Tgav",
+         year >= 2015 & year <= 2100) %>% 
+  # compute median, min, max, etc. for all remaining runs
+  group_by(year, ssp) %>%
+  summarize(sdev = sd(value),
+            minimum = min(value),
+            maximum = max(value),
+            med = median(value), .groups = "drop") %>% 
+  # combine with CMIP6 data
+  mutate(source = "Hector") %>% 
+  bind_rows(cmip_scenarios) %>%
+  # ...and plot
+  ggplot(aes(year, fill = source, color = source)) +
+  geom_ribbon(aes(ymin = minimum, ymax = maximum), alpha = 0.15, color = NA) +
+  geom_ribbon(aes(ymin = med - sdev, ymax = med + sdev), alpha = 0.5, color = NA) +
+  geom_line(aes(y = med), size = 2) +
+  scale_color_viridis_d(begin = 0.5) +
+  scale_fill_viridis_d(begin = 0.5) +
+  facet_wrap(~ssp, scales = "free") +
+  theme(legend.title = element_blank()) +
+  labs(x = "Year",
+       y = expression(degree*C))
 ```
 
 ## Atmosphere sources - ƒATM~ffi~
@@ -278,48 +193,6 @@ ggplot(ff, aes(year)) +
        y = "Fraction of atmospheric CO2")
 ```
 
-``` {r coeff-var, fig.cap = " Coefficients of variability for each source in the atmosphere over time."}
-# Compute coefficient of variability for each source in the atmosphere pool
-atmos_cv <- atmosphere_pool %>%
-  group_by(year, source_name) %>%
-  mutate(sdev = sd(source_fraction),
-         mean = mean(source_fraction),
-         cv = sdev / mean)
-
-# Plot the coefficient of variability for each source in atmosphere pool over time
-ggplot(atmos_cv, aes(year, cv, group = source_name, color = source_name)) +
-  geom_line() +
-  scale_color_viridis_d() +
-  labs(x = "Source fraction",
-       y = "Coefficient of variability") +
-  xlim(1800, 2300) +
-  ylim(0, 0.25)
-
-```
-
-```{r parameter-space, fig.cap = " Parameter correlations and distributions (diagonal), with color indicating how much of the atmosphere is composed of anthropogenic CO2 in the year 2100."}
-# Exploring how the parameter space is linked to output
-# What parameters control the percentage of earth_c in the atmosphere?
-# Isolating the year 2100
-
-ffi_atm_2100 <- atmosphere_pool %>%
-  filter(source_name == "earth_c",
-         year == 2100) %>% 
-  mutate(sf = cut(source_fraction, 3))
-
-n <- length(name_vector)
-ggpairs(ffi_atm_2100,
-        columns = 10:(10 + (n-1)),
-        # Color by magnitude of source_fraction - how much earth_c is in the atmosphere
-        aes(color = sf), 
-        diag = list(mapping = aes(alpha = 0.5)),
-        upper = list(continuous = "blank"),
-        legend = c(6,5)) + 
-  scale_color_viridis_d() + 
-  scale_fill_viridis_d() +
-  labs(color = "Source Fraction")
-```
-
 ## Destination of FFI emissions - ƒFFI~atm~
 
 ```{r destination, fig.cap = " Final destination pools of fossil fuel and industrial (FFI) emissions for 16 random runs."}
@@ -339,13 +212,15 @@ ffi_destinations <- trk_output_filtered %>%
 dest_runs <- ffi_destinations %>%
   group_by(ssp) %>%
   filter(year == min(year)) %>%
-  slice_sample(n = 5) %>% 
+  slice_sample(n = 5) %>%
   summarize(run_number)
-  
+
 dest_plot <- filter(ffi_destinations, 
                     run_number %in% dest_runs$run_number) 
 
+# Just looking at the mean of all runs in SSP245
 dest_plot %>%
+  filter(ssp == MAIN_SCENARIO) %>%
   group_by(ssp, year, pool_name) %>%
   mutate(dest_avg = mean(destination_fraction)) %>%
   filter(run_number == min(run_number)) %>%
@@ -356,10 +231,10 @@ dest_plot %>%
                     labels = c("Atmosphere", "Deep ocean", "Detritus",
                                "High-lat ocean", "Intermed. ocean",
                                "Low-lat ocean", "Soil", "Vegetation")) +
-  facet_wrap(~ssp) +
-  theme(#strip.background = element_blank(),
+  # facet_wrap(~ssp) +
+  #theme(#strip.background = element_blank(),
         #strip.text.x = element_blank(),
-        axis.text.x = element_text(angle = 90)) +
+        #axis.text.x = element_text(angle = 90)) +
   labs(x = "Year",
        y = "Fraction of FFI emissions",
        fill = "Destination")
@@ -423,57 +298,58 @@ ggplot(relimp_out, aes(year, value, fill = param)) +
   theme(axis.text.x = element_text(angle = 90))
 ```
 
-## Airborne fraction
+## Does time affect destination?
 
-```{r af-windows, fig.cap = " Airborne fraction computed over varying time windows."}
-# Prep the data
-atm_earth_diffs <- trk_output_filtered %>%
-  # Isolate atmosphere and earth total pool values
-  filter(pool_name %in% c("atmos_c", "earth_c")) %>% 
-  group_by(run_number, year, pool_name, ssp) %>% 
-  summarise(pool_value = mean(pool_value), .groups = "drop") %>% 
-  arrange(year) %>%
-  # Put atmosphere and earth in separate columns and compute diffs
-  pivot_wider(names_from = "pool_name", values_from = "pool_value") %>% 
-  group_by(run_number, ssp) %>%
-  mutate(atm_diff = c(NA, diff(atmos_c)), 
-         earth_diff = c(NA, diff(earth_c)))
+```{r tracking-multiple-years, warning = FALSE, fig.cap = " Amount of CO2 in the atmosphere sourced from human emissions. Note that turning on tracking in different years does not have a dramatic effect on the composition of the atmosphere pool."}
+# Prepare data: reset the core, set start dates every 50 years
+tcore <- newcore(SSP_files[[MAIN_SCENARIO]])
+dates <- seq(from = 1750, to = 2250, 50)
+tracking_output <- list()
 
-# Compute AF (classical definition of delta CO2atm / emissions) 
-# using various window sizes
-af_results <- list()
-for(groupsize in seq(1, 40, length.out = 10)) {
-  ngroups = length(unique(atm_earth_diffs$year)) / groupsize
-  
-  atm_earth_diffs %>% 
-    group_by(run_number, ssp) %>% 
-    mutate(group = cut(year, breaks = ngroups)) %>% 
-    # compute differences over the group of years
-    group_by(run_number, group, ssp) %>%
-    summarise(year = max(year), 
-              atm_diff = sum(atm_diff), 
-              earth_diff = sum(earth_diff), 
-              n = n(),
-              af = atm_diff / -earth_diff,
-              .groups = "drop") ->
-    af_results[[as.character(groupsize)]]
+# Function to set a tracking date, run the core for a 50 year period, and retrieve tracking data
+set_tracking <- function(c, date){
+  setvar(c, NA, TRACKING_DATE(), date, "(unitless)")
+  reset(c)
+  run(c, (date + 50))
+  tdata <- get_tracking_data(c)
+  tdata$ty <- date
+  tdata$ssp <- MAIN_SCENARIO
+  tdata
 }
 
-af_results <- bind_rows(af_results, .id = "window_size") %>% 
-  mutate(window_size = as.integer(window_size))
+# Loop through above function for desired dates
+for(d in dates){
+  tracking_output[[d]] <- set_tracking(tcore, d)
+}
 
-af_results %>% 
-  group_by(year, ssp, window_size) %>% 
-  summarise(af = mean(af), .groups = "drop") %>% 
-  filter(year %in% 1900:2200) %>%
-  ggplot(aes(year, af, color = window_size, group = window_size)) + 
-  geom_line(na.rm = TRUE) + 
-  facet_wrap(~ssp, scales = "free") +
+all_years_tracking <- bind_rows(tracking_output)
+
+# Plot the fraction of the atmosphere that is sourced from earth_c
+# all_years_tracking %>%
+#   filter(source_name == "earth_c",
+#          pool_name == "atmos_c") %>%
+#   ggplot(aes(year, source_fraction, color = ty, group = ty)) +
+#   geom_line() +
+#   labs(x = "Year",
+#        y = "Source fraction") +
+#   scale_color_viridis_c()
+
+# Plot the destination of earth_c emissions
+all_years_tracking %>%
+  filter(source_name == "earth_c", pool_name != "earth_c") %>%
+  mutate(source_quantity = pool_value * source_fraction) %>%
+  group_by(year) %>%
+  mutate(destination_fraction = source_quantity / sum(source_quantity)) %>% 
+  ungroup() %>%
+  ggplot(aes(year, destination_fraction, fill = pool_name), group = ty) +
+  geom_area() +
   labs(x = "Year",
-       y = "Airborne fraction") 
+       y = "Destination fraction") +
+  scale_fill_viridis_d()
 
 ```
 
+## Airborne fraction
 
 ```{r airborne, warning = FALSE, fig.cap = " Year-by-year mathematically defined airborne fraction. The yellow line and band shows the actual amount of human emissions remaining in the atmosphere from the model's carbon-tracking mechanism."}
 # Compute cumulative emissions over time
@@ -567,56 +443,195 @@ ggplot(plot_data, aes(x = year, fill = def)) +
 
 ```
 
-## Turning on tracking at different dates
 
-```{r tracking-multiple-years, warning = FALSE, fig.cap = " Amount of CO2 in the atmosphere sourced from human emissions. Note that turning on tracking in different years does not have a dramatic effect on the composition of the atmosphere pool."}
-# Prepare data: reset the core, set start dates every 50 years
-tcore <- newcore(SSP_files[[MAIN_SCENARIO]])
-dates <- seq(from = 1750, to = 2250, 50)
-tracking_output <- list()
+# Supplementary figures
 
-# Function to set a tracking date, run the core for a 50 year period, and retrieve tracking data
-set_tracking <- function(c, date){
-  setvar(c, NA, TRACKING_DATE(), date, "(unitless)")
-  reset(c)
-  run(c, (date + 50))
-  tdata <- get_tracking_data(c)
-  tdata$ty <- date
-  tdata$ssp <- MAIN_SCENARIO
-  tdata
-}
+## Realized parameter PDFs
 
-# Loop through above function for desired dates
-for(d in dates){
-  tracking_output[[d]] <- set_tracking(tcore, d)
-}
+``` {r params-PDFs, fig.cap = paste0(" Probability densities of each parameter (N=", SSP_runs[[MAIN_SCENARIO]], " draws).")}
+# Density plots to visualize parameter distributions
+runlist %>% 
+  filter(ssp == MAIN_SCENARIO) %>%
+  select(-c(run_number, ssp)) %>%
+  pivot_longer(everything()) %>% 
+  ggplot(aes(value)) +
+  geom_density() + 
+  facet_wrap(~name, scales = "free") +
+  labs(x = NULL, y = NULL)
+```
 
-all_years_tracking <- bind_rows(tracking_output)
+## Hector temperature vs CMIP6 diagnostic
 
-# Plot the fraction of the atmosphere that is sourced from earth_c
-all_years_tracking %>%
-  filter(source_name == "earth_c",
-         pool_name == "atmos_c") %>%
-  ggplot(aes(year, source_fraction, color = ty, group = ty)) +
-  geom_line() +
+``` {r cmip, message = FALSE, fig.cap = " Visualization of sample model runs. The black dots represent the CMIP6 minimums and maximums for global temperature anomaly, and the runs that pass must fall within these bounds more than 50% of the time."}
+# Read in CMIP6 comparison data
+cmip_raw <- read.csv("./data_files/CMIP6_annual_tas_global.csv")
+
+# Isolate desired scenarios
+cmip_sce <- list()
+for(n in names(SSP_files)){
+  cmip_sce[[n]] <- cmip_raw %>% 
+    filter(experiment == n)
+}  
+cmip_sce <- bind_rows(cmip_sce) 
+
+# Filter for Tgav and calculate summary metrics
+cmip_scenarios <- cmip_sce %>%
+  rename(ssp = experiment) %>%
+  filter(variable == "Tgav",
+         year <= 2100) %>%
+  group_by(year, ssp) %>%
+  summarize(sdev = sd(value),
+            minimum = min(value),
+            maximum = max(value),
+            med = median(value)) %>%
+  mutate(source = "CMIP6") %>%
+  arrange(ssp, year)
+
+# Identify unrealistic runs - for each run, if more than 50% of values are
+# outside of the min/max of the CMIP data, the run is nixed
+cmip_bounds <- cmip_scenarios %>% 
+  group_by(ssp) %>%
+  select(year, minimum, maximum)
+
+hector_temp <- model_output %>%
+  filter(variable == "Tgav",
+         year >= 2015 & year <= 2100) %>%
+  select(run_number, ssp, year, value) %>%
+  left_join(cmip_bounds, by = c("year", "ssp")) %>% 
+  mutate(fail = value < minimum | value > maximum)
+
+run_fail_summary <- hector_temp %>%
+  group_by(ssp, run_number) %>%
+  summarise(fraction_fail = sum(fail) / n())
+
+# Make a table of failure rates
+run_fail_summary %>% 
+  group_by(fraction_fail > 0.5) %>% 
+  summarise(n()) %>% 
+  knitr::kable()
+
+# ...and a figure 
+hector_temp_runs <- hector_temp %>% 
+  group_by(ssp) %>%
+  filter(year == min(year)) %>%
+  slice_sample(n = 100) %>% # this is a debugging figure; plot just 100 runs for clarity
+  arrange(ssp, run_number) %>%
+  summarize(run_number)
+
+# Filter out data for just the 100 rusn per senario identified above
+hector_temp_slice <- left_join(hector_temp_runs, hector_temp, by = c("run_number", "ssp"))
+  
+# Plot
+left_join(hector_temp_slice, run_fail_summary, by = c("run_number", "ssp")) %>%
+  ggplot(aes(year, value, color = fraction_fail, group = run_number)) + 
+  geom_line() + 
+  geom_point(aes(y = minimum), color = "black") + 
+  geom_point(aes(y = maximum), color = "black") +
+  facet_wrap(~ssp) +
+  scale_color_viridis_c() +
   labs(x = "Year",
-       y = "Source fraction") +
-  scale_color_viridis_c()
-
-# Plot the destination of earth_c emissions
-all_years_tracking %>%
-  filter(source_name == "earth_c", pool_name != "earth_c") %>%
-  mutate(source_quantity = pool_value * source_fraction) %>%
-  group_by(year) %>%
-  mutate(destination_fraction = source_quantity / sum(source_quantity)) %>% 
-  ungroup() %>%
-  ggplot(aes(year, destination_fraction, fill = pool_name), group = ty) +
-  geom_area() +
-  labs(x = "Year",
-       y = "Destination fraction") +
-  scale_fill_viridis_d()
+       y = expression(degree*C))
 
 ```
+
+## Source coefficients of variability
+
+``` {r coeff-var, fig.cap = " Coefficients of variability for each source in the atmosphere over time."}
+# Compute coefficient of variability for each source in the atmosphere pool
+atmos_cv <- atmosphere_pool %>%
+  group_by(year, source_name) %>%
+  mutate(sdev = sd(source_fraction),
+         mean = mean(source_fraction),
+         cv = sdev / mean)
+
+# Plot the coefficient of variability for each source in atmosphere pool over time
+ggplot(atmos_cv, aes(year, cv, group = source_name, color = source_name)) +
+  geom_line() +
+  scale_color_viridis_d() +
+  labs(x = "Source fraction",
+       y = "Coefficient of variability") +
+  xlim(1800, 2300) +
+  ylim(0, 0.25)
+
+```
+
+## Parameter distributions and source fraction controls
+
+```{r parameter-space, fig.cap = " Parameter correlations and distributions (diagonal), with color indicating how much of the atmosphere is composed of anthropogenic CO2 in the year 2100."}
+# Exploring how the parameter space is linked to output
+# What parameters control the percentage of earth_c in the atmosphere?
+# Isolating the year 2100
+
+ffi_atm_2100 <- atmosphere_pool %>%
+  filter(source_name == "earth_c",
+         year == 2100) %>% 
+  mutate(sf = cut(source_fraction, 3))
+
+n <- length(name_vector)
+ggpairs(ffi_atm_2100,
+        columns = 10:(10 + (n-1)),
+        # Color by magnitude of source_fraction - how much earth_c is in the atmosphere
+        aes(color = sf), 
+        diag = list(mapping = aes(alpha = 0.5)),
+        upper = list(continuous = "blank"),
+        legend = c(6,5)) + 
+  scale_color_viridis_d() + 
+  scale_fill_viridis_d() +
+  labs(color = "Source Fraction")
+```
+
+## Airborne fraction time windows
+
+```{r af-windows, fig.cap = " Airborne fraction computed over varying time windows."}
+# Prep the data
+atm_earth_diffs <- trk_output_filtered %>%
+  # Isolate atmosphere and earth total pool values
+  filter(pool_name %in% c("atmos_c", "earth_c")) %>% 
+  group_by(run_number, year, pool_name, ssp) %>% 
+  summarise(pool_value = mean(pool_value), .groups = "drop") %>% 
+  arrange(year) %>%
+  # Put atmosphere and earth in separate columns and compute diffs
+  pivot_wider(names_from = "pool_name", values_from = "pool_value") %>% 
+  group_by(run_number, ssp) %>%
+  mutate(atm_diff = c(NA, diff(atmos_c)), 
+         earth_diff = c(NA, diff(earth_c)))
+
+# Compute AF (classical definition of delta CO2atm / emissions) 
+# using various window sizes
+af_results <- list()
+for(groupsize in seq(1, 40, length.out = 10)) {
+  ngroups = length(unique(atm_earth_diffs$year)) / groupsize
+  
+  atm_earth_diffs %>% 
+    group_by(run_number, ssp) %>% 
+    mutate(group = cut(year, breaks = ngroups)) %>% 
+    # compute differences over the group of years
+    group_by(run_number, group, ssp) %>%
+    summarise(year = max(year), 
+              atm_diff = sum(atm_diff), 
+              earth_diff = sum(earth_diff), 
+              n = n(),
+              af = atm_diff / -earth_diff,
+              .groups = "drop") ->
+    af_results[[as.character(groupsize)]]
+}
+
+af_results <- bind_rows(af_results, .id = "window_size") %>% 
+  mutate(window_size = as.integer(window_size))
+
+af_results %>% 
+  group_by(year, ssp, window_size) %>% 
+  summarise(af = mean(af), .groups = "drop") %>% 
+  filter(year %in% 1900:2200) %>%
+  ggplot(aes(year, af, color = window_size, group = window_size)) + 
+  geom_line(na.rm = TRUE) + 
+  facet_wrap(~ssp, scales = "free") +
+  labs(x = "Year",
+       y = "Airborne fraction") 
+
+```
+
+## Tracking year plus one (work in progress)
 
 ``` {r tracking-af}
 # We want to calculate airborne fraction in the year immediately following the 

--- a/trackingC.Rmd
+++ b/trackingC.Rmd
@@ -58,6 +58,94 @@ in a manuscript.
 
 # Primary figures
 
+## Hector temperature vs. CMIP6 
+
+``` {r filtered, fig.cap = "Global temperature anomaly from CMIP6 and filtered Hector runs. Lines show median; shaded areas show ±1 s.d. of median (darker) and minimum and maximum of ensemble (lighter)."}
+# Read in CMIP6 comparison data
+cmip_raw <- read.csv("./data_files/CMIP6_annual_tas_global.csv")
+
+# Isolate desired scenarios
+cmip_sce <- list()
+for(n in names(SSP_files)){
+  cmip_sce[[n]] <- cmip_raw %>% 
+    filter(experiment == n)
+}  
+cmip_sce <- bind_rows(cmip_sce) 
+
+# Filter for Tgav and calculate summary metrics
+cmip_scenarios <- cmip_sce %>%
+  rename(ssp = experiment) %>%
+  filter(variable == "Tgav",
+         year <= 2100) %>%
+  group_by(year, ssp) %>%
+  summarize(sdev = sd(value),
+            minimum = min(value),
+            maximum = max(value),
+            med = median(value)) %>%
+  mutate(source = "CMIP6") %>%
+  arrange(ssp, year)
+
+# Identify unrealistic runs - for each run, if more than 50% of values are
+# outside of the min/max of the CMIP data, the run is nixed
+cmip_bounds <- cmip_scenarios %>% 
+  group_by(ssp) %>%
+  select(year, minimum, maximum)
+
+hector_temp <- model_output %>%
+  filter(variable == "Tgav",
+         year >= 2015 & year <= 2100) %>%
+  select(run_number, ssp, year, value) %>%
+  left_join(cmip_bounds, by = c("year", "ssp")) %>% 
+  mutate(fail = value < minimum | value > maximum)
+
+run_fail_summary <- hector_temp %>%
+  group_by(ssp, run_number) %>%
+  summarise(fraction_fail = sum(fail) / n())
+
+# Filter out 'unrealistic' runs (identified above)
+model_output_filtered <- model_output %>%
+  left_join(run_fail_summary, by = c("ssp", "run_number")) %>% 
+  filter(fraction_fail < 0.5)
+
+# Note that the tracking output needs to be filtered as well
+trk_output_filtered <- trk_output %>%
+  left_join(run_fail_summary, by = c("ssp", "run_number")) %>% 
+  filter(fraction_fail < 0.5)
+
+# Create facet labels
+var_labels <- c("SSP119", "SSP245", "SSP370", "SSP460", "SSP585")
+names(var_labels) <- c("ssp119", "ssp245", "ssp370", "ssp460", "ssp585")
+
+# Plot temperature spreads for the filtered runs
+model_output_filtered %>%
+  filter(variable == "Tgav",
+         year >= 2015 & year <= 2100) %>% 
+  # compute median, min, max, etc. for all remaining runs
+  group_by(year, ssp) %>%
+  summarize(sdev = sd(value),
+            minimum = min(value),
+            maximum = max(value),
+            med = median(value), .groups = "drop") %>% 
+  # combine with CMIP6 data
+  mutate(source = "Hector") %>% 
+  bind_rows(cmip_scenarios) %>%
+  # ...and plot
+  ggplot(aes(year, fill = source, color = source)) +
+  geom_ribbon(aes(ymin = minimum, ymax = maximum), alpha = 0.15, color = NA) +
+  geom_ribbon(aes(ymin = med - sdev, ymax = med + sdev), alpha = 0.5, color = NA) +
+  geom_line(aes(y = med), size = 2) +
+  scale_color_viridis_d(begin = 0.5) +
+  scale_fill_viridis_d(begin = 0.5) +
+  facet_wrap(~ssp, scales = "free",
+             labeller = labeller(ssp = var_labels)) +
+  #theme(legend.title = element_blank()) +
+  labs(x = "Year",
+       y = expression(degree*C),
+       color = "Source",
+       fill = "Source")
+```
+
+
 ## Hector atmospheric CO~2~ vs observed data
 
 ``` {r ca-comp, fig.cap = " Historical CO2 data from Hector runs, NOAA observations, and CMIP6 models."}
@@ -65,7 +153,8 @@ in a manuscript.
 # https://gml.noaa.gov/ccgg/trends/data.html
 noaa <- read.csv("./data_files/noaa_co2_data.csv")
 noaa_co2 <- noaa %>% 
-  mutate(source = "NOAA")
+  mutate(source = "NOAA") %>%
+  filter(year < 2015)
 
 cmip_c <- read.csv("./data_files/CMIP6_annual_co2.csv")
 cmip_co2 <- cmip_c %>%
@@ -97,6 +186,7 @@ hector_co2 <- model_output_filtered %>%
 plot_data_co2 <- bind_rows(cmip_co2, hector_co2)
 
 plot_data_co2 %>% 
+  filter(year < 2015) %>%
   ggplot(aes(year, fill = source, color = source)) +
   geom_ribbon(aes(ymin = minimum, ymax = maximum), alpha = 0.15, color = NA) +
   geom_ribbon(aes(ymin = med - sdev, ymax = med + sdev), alpha = 0.5, color = NA) +
@@ -105,47 +195,10 @@ plot_data_co2 %>%
   scale_color_viridis_d(begin = 0.5) +
   scale_fill_viridis_d(begin = 0.5) +
   labs(x = "Year",
-       y = "CO2 (ppm)")
+       y = "CO2 (ppm)",
+       color = "Source",
+       fill = "Source")
 
-```
-
-## Hector temperature vs. CMIP6 
-
-``` {r filtered, fig.cap = "Global temperature anomaly from CMIP6 and filtered Hector runs. Lines show median; shaded areas show ±1 s.d. of median (darker) and minimum and maximum of ensemble (lighter)."}
-# Filter out 'unrealistic' runs (identified above)
-model_output_filtered <- model_output %>%
-  left_join(run_fail_summary, by = c("ssp", "run_number")) %>% 
-  filter(fraction_fail < 0.5)
-
-# Note that the tracking output needs to be filtered as well
-trk_output_filtered <- trk_output %>%
-  left_join(run_fail_summary, by = c("ssp", "run_number")) %>% 
-  filter(fraction_fail < 0.5)
-  
-# Plot temperature spreads for the filtered runs
-model_output_filtered %>%
-  filter(variable == "Tgav",
-         year >= 2015 & year <= 2100) %>% 
-  # compute median, min, max, etc. for all remaining runs
-  group_by(year, ssp) %>%
-  summarize(sdev = sd(value),
-            minimum = min(value),
-            maximum = max(value),
-            med = median(value), .groups = "drop") %>% 
-  # combine with CMIP6 data
-  mutate(source = "Hector") %>% 
-  bind_rows(cmip_scenarios) %>%
-  # ...and plot
-  ggplot(aes(year, fill = source, color = source)) +
-  geom_ribbon(aes(ymin = minimum, ymax = maximum), alpha = 0.15, color = NA) +
-  geom_ribbon(aes(ymin = med - sdev, ymax = med + sdev), alpha = 0.5, color = NA) +
-  geom_line(aes(y = med), size = 2) +
-  scale_color_viridis_d(begin = 0.5) +
-  scale_fill_viridis_d(begin = 0.5) +
-  facet_wrap(~ssp, scales = "free") +
-  theme(legend.title = element_blank()) +
-  labs(x = "Year",
-       y = expression(degree*C))
 ```
 
 ## Atmosphere sources - ƒATM~ffi~
@@ -153,16 +206,25 @@ model_output_filtered %>%
 ``` {r atmosphere-by-source, fig.cap = paste0(" Fraction of CO2 in the atmosphere by source pool from 100 random runs in ", MAIN_SCENARIO, ". Dark line shows the median.")}
 # Isolate the atmosphere pool to better understand its composition 
 atmosphere_pool <- trk_output_filtered %>%
-  filter(ssp == MAIN_SCENARIO,
-         pool_name == "atmos_c")
+  filter(pool_name == "atmos_c")
+
+# Create facet labels
+### FIX THIS
+var_labels_s <- c("atmos_c", "deep", "detritus_c", "HL", "intermediate",
+                               "LL", "soil_c", "veg_c")
+names(var_labels_s) <- c("Atmosphere", "Deep ocean", "Detritus",
+                               "High-lat ocean", "Intermed. ocean",
+                               "Low-lat ocean", "Soil", "Vegetation")
 
 # This plot looks at source fraction by source pool in the atmosphere and the median run.
 atmosphere_pool %>%
-  filter(run_number %in% max_display$run_number) %>%
+  filter(ssp == MAIN_SCENARIO,
+         run_number %in% max_display$run_number) %>%
   ggplot(aes(year, source_fraction, 
              color = as.factor(run_number), group = run_number)) +
   geom_line(size = 0.5, show.legend = FALSE) +
-  facet_wrap( ~ source_name, scales = "free") +
+  facet_wrap(~source_name, scales = "free"
+             #labeller = labeller(source_name = var_labels_s)) +
   labs(x = "Year",
        y = "Source fraction") +
   scale_color_grey(start = 0.7, end = 0.7) +
@@ -179,18 +241,24 @@ atmosphere_pool %>%
 
 ff <- atmosphere_pool %>% 
   filter(source_name == "earth_c") %>%
-  group_by(year) %>%
+  group_by(ssp, year) %>%
   mutate(sf_sd = sd(source_fraction), 
             sf_min = min(source_fraction),
             sf_max = max(source_fraction),
             sf_median = median(source_fraction))
 
-ggplot(ff, aes(year)) +
-  geom_line(aes(y = sf_median)) +
+ggplot(ff, aes(year, color = ssp, fill = ssp)) +
+  geom_line(aes(y = sf_median), size = 2) +
   geom_ribbon(aes(ymin = sf_min, ymax = sf_max), alpha = 0.2) +
   geom_ribbon(aes(ymin = sf_median - sf_sd, ymax = sf_median + sf_sd), alpha = 0.2) +
+  scale_color_viridis_d(breaks = c("ssp119", "ssp245", "ssp370", "ssp460", "ssp585"),
+                        labels = c("SSP119", "SSP245", "SSP370", "SSP460", "SSP585")) + 
+  scale_fill_viridis_d(breaks = c("ssp119", "ssp245", "ssp370", "ssp460", "ssp585"),
+                        labels = c("SSP119", "SSP245", "SSP370", "SSP460", "SSP585")) +
   labs(x = "Year",
-       y = "Fraction of atmospheric CO2")
+       y = "Fraction of atmospheric CO2",
+       color = "Scenario",
+       fill = "Scenario")
 ```
 
 ## Destination of FFI emissions - ƒFFI~atm~
@@ -275,9 +343,6 @@ calc_relimp <- function(x) {
 dest_split <- split(dest_e2a_minimal, list(dest_e2a_minimal$year, dest_e2a_minimal$ssp))
 relimp_out <- lapply(dest_split, FUN = calc_relimp) %>% 
   bind_rows()
-
-var_labels <- c("SSP119", "SSP245", "SSP370", "SSP460", "SSP585")
-names(var_labels) <- c("ssp119", "ssp245", "ssp370", "ssp460", "ssp585")
     
 # ...and plot!
 ggplot(relimp_out, aes(year, value, fill = param)) + 
@@ -344,14 +409,81 @@ all_years_tracking %>%
   ggplot(aes(year, destination_fraction, fill = pool_name), group = ty) +
   geom_area() +
   labs(x = "Year",
-       y = "Destination fraction") +
-  scale_fill_viridis_d()
+       y = "Destination fraction",
+       fill = "Parameter") +
+  scale_fill_viridis_d(breaks = c("atmos_c", "deep", "detritus_c", "HL", "intermediate",
+                               "LL", "soil_c", "veg_c"),
+                    labels = c("Atmosphere", "Deep ocean", "Detritus",
+                               "High-lat ocean", "Intermed. ocean",
+                               "Low-lat ocean", "Soil", "Vegetation"))
 
 ```
 
 ## Airborne fraction
 
 ```{r airborne, warning = FALSE, fig.cap = " Year-by-year mathematically defined airborne fraction. The yellow line and band shows the actual amount of human emissions remaining in the atmosphere from the model's carbon-tracking mechanism."}
+# Exploring how the parameter space is linked to output
+# What parameters control the percentage of earth_c in the atmosphere?
+# Isolating the year 2100
+
+ffi_atm_2100 <- atmosphere_pool %>%
+  filter(source_name == "earth_c",
+         year == 2100) %>% 
+  mutate(sf = cut(source_fraction, 3))
+
+n <- length(name_vector)
+ggpairs(ffi_atm_2100,
+        columns = 10:(10 + (n-1)),
+        # Color by magnitude of source_fraction - how much earth_c is in the atmosphere
+        aes(color = sf), 
+        diag = list(mapping = aes(alpha = 0.5)),
+        upper = list(continuous = "blank"),
+        legend = c(6,5)) + 
+  scale_color_viridis_d() + 
+  scale_fill_viridis_d() +
+  labs(color = "Source Fraction")
+```
+
+## Airborne fraction time windows
+
+```{r af-windows, fig.cap = " Airborne fraction computed over varying time windows."}
+# Prep the data
+atm_earth_diffs <- trk_output_filtered %>%
+  # Isolate atmosphere and earth total pool values
+  filter(pool_name %in% c("atmos_c", "earth_c")) %>% 
+  group_by(run_number, year, pool_name, ssp) %>% 
+  summarise(pool_value = mean(pool_value), .groups = "drop") %>% 
+  arrange(year) %>%
+  # Put atmosphere and earth in separate columns and compute diffs
+  pivot_wider(names_from = "pool_name", values_from = "pool_value") %>% 
+  group_by(run_number, ssp) %>%
+  mutate(atm_diff = c(NA, diff(atmos_c)), 
+         earth_diff = c(NA, diff(earth_c)))
+
+# Compute AF (classical definition of delta CO2atm / emissions) 
+# using various window sizes
+af_results <- list()
+for(groupsize in seq(1, 40, length.out = 10)) {
+  ngroups = length(unique(atm_earth_diffs$year)) / groupsize
+  
+  atm_earth_diffs %>% 
+    group_by(run_number, ssp) %>% 
+    mutate(group = cut(year, breaks = ngroups)) %>% 
+    # compute differences over the group of years
+    group_by(run_number, group, ssp) %>%
+    summarise(year = max(year), 
+              atm_diff = sum(atm_diff), 
+              earth_diff = sum(earth_diff), 
+              n = n(),
+              af = atm_diff / -earth_diff,
+              .groups = "drop") ->
+    af_results[[as.character(groupsize)]]
+}
+
+af_results <- bind_rows(af_results, .id = "window_size") %>% 
+  mutate(window_size = as.integer(window_size))
+
+
 # Compute cumulative emissions over time
 # We use the change in earth_c to compute emissions; note this will not work
 # if ever using a scenario with fossil fuel sequestration (atmosphere -> earth)
@@ -463,47 +595,7 @@ runlist %>%
 ## Hector temperature vs CMIP6 diagnostic
 
 ``` {r cmip, message = FALSE, fig.cap = " Visualization of sample model runs. The black dots represent the CMIP6 minimums and maximums for global temperature anomaly, and the runs that pass must fall within these bounds more than 50% of the time."}
-# Read in CMIP6 comparison data
-cmip_raw <- read.csv("./data_files/CMIP6_annual_tas_global.csv")
-
-# Isolate desired scenarios
-cmip_sce <- list()
-for(n in names(SSP_files)){
-  cmip_sce[[n]] <- cmip_raw %>% 
-    filter(experiment == n)
-}  
-cmip_sce <- bind_rows(cmip_sce) 
-
-# Filter for Tgav and calculate summary metrics
-cmip_scenarios <- cmip_sce %>%
-  rename(ssp = experiment) %>%
-  filter(variable == "Tgav",
-         year <= 2100) %>%
-  group_by(year, ssp) %>%
-  summarize(sdev = sd(value),
-            minimum = min(value),
-            maximum = max(value),
-            med = median(value)) %>%
-  mutate(source = "CMIP6") %>%
-  arrange(ssp, year)
-
-# Identify unrealistic runs - for each run, if more than 50% of values are
-# outside of the min/max of the CMIP data, the run is nixed
-cmip_bounds <- cmip_scenarios %>% 
-  group_by(ssp) %>%
-  select(year, minimum, maximum)
-
-hector_temp <- model_output %>%
-  filter(variable == "Tgav",
-         year >= 2015 & year <= 2100) %>%
-  select(run_number, ssp, year, value) %>%
-  left_join(cmip_bounds, by = c("year", "ssp")) %>% 
-  mutate(fail = value < minimum | value > maximum)
-
-run_fail_summary <- hector_temp %>%
-  group_by(ssp, run_number) %>%
-  summarise(fraction_fail = sum(fail) / n())
-
+# Visualize the run fail summary calculated above
 # Make a table of failure rates
 run_fail_summary %>% 
   group_by(fraction_fail > 0.5) %>% 
@@ -527,10 +619,12 @@ left_join(hector_temp_slice, run_fail_summary, by = c("run_number", "ssp")) %>%
   geom_line() + 
   geom_point(aes(y = minimum), color = "black") + 
   geom_point(aes(y = maximum), color = "black") +
-  facet_wrap(~ssp) +
+  facet_wrap(~ssp,
+             labeller = labeller(ssp = var_labels)) +
   scale_color_viridis_c() +
   labs(x = "Year",
-       y = expression(degree*C))
+       y = expression(degree*C),
+       color = "Fraction of failed runs")
 
 ```
 
@@ -539,6 +633,7 @@ left_join(hector_temp_slice, run_fail_summary, by = c("run_number", "ssp")) %>%
 ``` {r coeff-var, fig.cap = " Coefficients of variability for each source in the atmosphere over time."}
 # Compute coefficient of variability for each source in the atmosphere pool
 atmos_cv <- atmosphere_pool %>%
+  filter(ssp == MAIN_SCENARIO) %>%
   group_by(year, source_name) %>%
   mutate(sdev = sd(source_fraction),
          mean = mean(source_fraction),
@@ -547,9 +642,14 @@ atmos_cv <- atmosphere_pool %>%
 # Plot the coefficient of variability for each source in atmosphere pool over time
 ggplot(atmos_cv, aes(year, cv, group = source_name, color = source_name)) +
   geom_line() +
-  scale_color_viridis_d() +
+  scale_color_viridis_d(breaks = c("atmos_c", "deep", "detritus_c", "HL", "intermediate",
+                               "LL", "soil_c", "veg_c"),
+                    labels = c("Atmosphere", "Deep ocean", "Detritus",
+                               "High-lat ocean", "Intermed. ocean",
+                               "Low-lat ocean", "Soil", "Vegetation")) +
   labs(x = "Source fraction",
-       y = "Coefficient of variability") +
+       y = "Coefficient of variability",
+       color = "Source parameter") +
   xlim(1800, 2300) +
   ylim(0, 0.25)
 
@@ -561,12 +661,10 @@ ggplot(atmos_cv, aes(year, cv, group = source_name, color = source_name)) +
 # Exploring how the parameter space is linked to output
 # What parameters control the percentage of earth_c in the atmosphere?
 # Isolating the year 2100
-
 ffi_atm_2100 <- atmosphere_pool %>%
   filter(source_name == "earth_c",
          year == 2100) %>% 
   mutate(sf = cut(source_fraction, 3))
-
 n <- length(name_vector)
 ggpairs(ffi_atm_2100,
         columns = 10:(10 + (n-1)),
@@ -580,54 +678,22 @@ ggpairs(ffi_atm_2100,
   labs(color = "Source Fraction")
 ```
 
-## Airborne fraction time windows
+# Airborne fraction window size
 
-```{r af-windows, fig.cap = " Airborne fraction computed over varying time windows."}
-# Prep the data
-atm_earth_diffs <- trk_output_filtered %>%
-  # Isolate atmosphere and earth total pool values
-  filter(pool_name %in% c("atmos_c", "earth_c")) %>% 
-  group_by(run_number, year, pool_name, ssp) %>% 
-  summarise(pool_value = mean(pool_value), .groups = "drop") %>% 
-  arrange(year) %>%
-  # Put atmosphere and earth in separate columns and compute diffs
-  pivot_wider(names_from = "pool_name", values_from = "pool_value") %>% 
-  group_by(run_number, ssp) %>%
-  mutate(atm_diff = c(NA, diff(atmos_c)), 
-         earth_diff = c(NA, diff(earth_c)))
-
-# Compute AF (classical definition of delta CO2atm / emissions) 
-# using various window sizes
-af_results <- list()
-for(groupsize in seq(1, 40, length.out = 10)) {
-  ngroups = length(unique(atm_earth_diffs$year)) / groupsize
-  
-  atm_earth_diffs %>% 
-    group_by(run_number, ssp) %>% 
-    mutate(group = cut(year, breaks = ngroups)) %>% 
-    # compute differences over the group of years
-    group_by(run_number, group, ssp) %>%
-    summarise(year = max(year), 
-              atm_diff = sum(atm_diff), 
-              earth_diff = sum(earth_diff), 
-              n = n(),
-              af = atm_diff / -earth_diff,
-              .groups = "drop") ->
-    af_results[[as.character(groupsize)]]
-}
-
-af_results <- bind_rows(af_results, .id = "window_size") %>% 
-  mutate(window_size = as.integer(window_size))
-
+```{r parameter-space, fig.cap = " Parameter correlations and distributions (diagonal), with color indicating how much of the atmosphere is composed of anthropogenic CO2 in the year 2100."}
+# Plot airborne fraction window size plot
 af_results %>% 
   group_by(year, ssp, window_size) %>% 
   summarise(af = mean(af), .groups = "drop") %>% 
   filter(year %in% 1900:2200) %>%
   ggplot(aes(year, af, color = window_size, group = window_size)) + 
   geom_line(na.rm = TRUE) + 
-  facet_wrap(~ssp, scales = "free") +
+  facet_wrap(~ssp, scales = "free",
+             labeller = labeller(ssp = var_labels)) +
+  scale_color_viridis_c() +
   labs(x = "Year",
-       y = "Airborne fraction") 
+       y = "Airborne fraction",
+       color = "Window size") 
 
 ```
 

--- a/trackingC.Rmd
+++ b/trackingC.Rmd
@@ -49,7 +49,6 @@ max_display <- slice_sample(runlist, n = 100)
 trk_output_slice <- filter(trk_output, run_number %in% max_display$run_number)
 model_output_slice <- filter(model_output, run_number %in% max_display$run_number)
 
-
 ```
 
 # Results
@@ -62,7 +61,8 @@ in a manuscript.
 ``` {r params-PDFs, fig.cap = paste0(" Probability densities of each parameter (N=", N_RUNS, " draws).")}
 # Density plots to visualize parameter distributions
 runlist %>% 
-  select(-run_number) %>%
+  filter(ssp == MAIN_SCENARIO) %>%
+  select(-c(run_number, ssp)) %>%
   pivot_longer(everything()) %>% 
   ggplot(aes(value)) +
   geom_density() + 
@@ -74,28 +74,44 @@ runlist %>%
 
 ``` {r cmip, fig.cap = " Visualization of sample model runs. The red dots represent the CMIP6 minimums and maximums for global temperature anomaly, and the runs that pass must fall within these bounds more than 50% of the time."}
 # Read in CMIP6 comparison data
-cmip <- read.csv("./data_files/CMIP6_annual_tas_global.csv") %>%
-  filter(variable == "Tgav",
-         experiment == "ssp245") %>%
-  group_by(year) %>%
+cmip_raw <- read.csv("./data_files/CMIP6_annual_tas_global.csv")
+
+# Isolate desired scenarios
+cmip_sce <- list()
+for(n in names(SSP_files)){
+  cmip_sce[[n]] <- cmip_raw %>% 
+    filter(experiment == n)
+}  
+cmip_sce <- bind_rows(cmip_sce) 
+
+# Filter for Tgav and calculate summary metrics
+cmip_scenarios <- cmip_sce %>%
+  rename(ssp = experiment) %>%
+  filter(variable == "Tgav") %>%
+  group_by(year, ssp) %>%
   summarize(sdev = sd(value),
             minimum = min(value),
             maximum = max(value),
             med = median(value)) %>%
-  mutate(source = "CMIP6")
+  mutate(source = "CMIP6") %>%
+  arrange(ssp, year)
 
 # Identify unrealistic runs - for each run, if more than 50% of values are
 # outside of the min/max of the CMIP data, the run is nixed
-cmip_bounds <- cmip %>% select(year, minimum, maximum)
+cmip_bounds <- cmip_scenarios %>% 
+  group_by(ssp) %>%
+  select(year, minimum, maximum)
+
 hector_temp <- model_output %>%
   filter(variable == "Tgav",
-         year >= 2015 & year <= 2100) %>%
-  select(run_number, year, value) %>%
-  left_join(cmip_bounds, by = "year") %>% 
+         year >= 2015 & year <= 2100,
+         run_number <= 100) %>%
+  select(run_number, ssp, year, value) %>%
+  left_join(cmip_bounds, by = c("year", "ssp")) %>% 
   mutate(fail = value < minimum | value > maximum)
 
 run_fail_summary <- hector_temp %>%
-  group_by(run_number) %>%
+  group_by(ssp, run_number) %>%
   summarise(fraction_fail = sum(fail) / n())
 
 # Make a table of failure rates
@@ -106,12 +122,13 @@ run_fail_summary %>%
 
 # ...and a figure 
 hector_temp %>% 
-  left_join(run_fail_summary, by = "run_number") %>% 
+  left_join(run_fail_summary, by = c("run_number", "ssp")) %>% 
   filter(run_number <= 100) %>% # this is a debugging figure; plot just 100 runs for clarity
   ggplot(aes(year, value, color = fraction_fail, group = run_number)) + 
   geom_line() + 
   geom_point(aes(y = minimum), color = "black") + 
   geom_point(aes(y = maximum), color = "black") +
+  facet_wrap(~ssp) +
   scale_color_viridis_c() +
   labs(x = "Year",
        y = expression(degree*C))

--- a/trackingC.Rmd
+++ b/trackingC.Rmd
@@ -58,7 +58,7 @@ in a manuscript.
 
 ## Realized parameter PDFs
 
-``` {r params-PDFs, fig.cap = paste0(" Probability densities of each parameter (N=", N_RUNS, " draws).")}
+``` {r params-PDFs, fig.cap = paste0(" Probability densities of each parameter (N=", N_RUNS_MAIN, " draws).")}
 # Density plots to visualize parameter distributions
 runlist %>% 
   filter(ssp == MAIN_SCENARIO) %>%
@@ -72,7 +72,7 @@ runlist %>%
 
 ## Hector temperature vs. CMIP6 
 
-``` {r cmip, fig.cap = " Visualization of sample model runs. The red dots represent the CMIP6 minimums and maximums for global temperature anomaly, and the runs that pass must fall within these bounds more than 50% of the time."}
+``` {r cmip, message = FALSE, fig.cap = " Visualization of sample model runs. The black dots represent the CMIP6 minimums and maximums for global temperature anomaly, and the runs that pass must fall within these bounds more than 50% of the time."}
 # Read in CMIP6 comparison data
 cmip_raw <- read.csv("./data_files/CMIP6_annual_tas_global.csv")
 
@@ -87,7 +87,8 @@ cmip_sce <- bind_rows(cmip_sce)
 # Filter for Tgav and calculate summary metrics
 cmip_scenarios <- cmip_sce %>%
   rename(ssp = experiment) %>%
-  filter(variable == "Tgav") %>%
+  filter(variable == "Tgav",
+         year <= 2100) %>%
   group_by(year, ssp) %>%
   summarize(sdev = sd(value),
             minimum = min(value),
@@ -150,14 +151,14 @@ model_output_filtered %>%
   filter(variable == "Tgav",
          year >= 2015 & year <= 2100) %>% 
   # compute median, min, max, etc. for all remaining runs
-  group_by(year) %>%
+  group_by(year, ssp) %>%
   summarize(sdev = sd(value),
             minimum = min(value),
             maximum = max(value),
             med = median(value), .groups = "drop") %>% 
   # combine with CMIP6 data
   mutate(source = "Hector") %>% 
-  bind_rows(cmip) %>%
+  bind_rows(cmip_scenarios) %>%
   # ...and plot
   ggplot(aes(year, fill = source, color = source)) +
   geom_ribbon(aes(ymin = minimum, ymax = maximum), alpha = 0.15, color = NA) +
@@ -165,6 +166,7 @@ model_output_filtered %>%
   geom_line(aes(y = med), size = 2) +
   scale_color_viridis_d(begin = 0.5) +
   scale_fill_viridis_d(begin = 0.5) +
+  facet_wrap(~ssp, scales = "free") +
   theme(legend.title = element_blank()) +
   labs(x = "Year",
        y = expression(degree*C))
@@ -227,7 +229,8 @@ plot_data_co2 %>%
 ``` {r atmosphere-by-source, fig.cap = " Fraction of CO2 in the atmosphere by source pool from 100 random runs. Dark line shows the median."}
 # Isolate the atmosphere pool to better understand its composition 
 atmosphere_pool <- trk_output_filtered %>%
-  filter(pool_name == "atmos_c")
+  filter(ssp == MAIN_SCENARIO,
+         pool_name == "atmos_c")
 
 # This plot looks at source fraction by source pool in the atmosphere and the median run.
 atmosphere_pool %>%
@@ -294,7 +297,7 @@ ffi_atm_2100 <- atmosphere_pool %>%
 
 n <- length(name_vector)
 ggpairs(ffi_atm_2100,
-        columns = 9:(9 + (n-1)),
+        columns = 10:(10 + (n-1)),
         # Color by magnitude of source_fraction - how much earth_c is in the atmosphere
         aes(color = sf), 
         diag = list(mapping = aes(alpha = 0.5)),
@@ -313,7 +316,7 @@ ggpairs(ffi_atm_2100,
 # Step 2: for each year and source_name, compute destination_fraction
 
 ffi_destinations <- trk_output_filtered %>%
-  filter(source_name == "earth_c", pool_name != "earth_c") %>%
+  filter(ssp == MAIN_SCENARIO, source_name == "earth_c", pool_name != "earth_c") %>%
   mutate(source_quantity = pool_value * source_fraction) %>%
   group_by(year, run_number) %>%
   mutate(destination_fraction = source_quantity / sum(source_quantity)) %>% 
@@ -383,7 +386,7 @@ ggplot(relimp_out, aes(year, value, fill = param)) +
 # Prep the data
 atm_earth_diffs <- trk_output_filtered %>%
   # Isolate atmosphere and earth total pool values
-  filter(pool_name %in% c("atmos_c", "earth_c")) %>% 
+  filter(ssp == MAIN_SCENARIO, pool_name %in% c("atmos_c", "earth_c")) %>% 
   group_by(run_number, year, pool_name) %>% 
   summarise(pool_value = mean(pool_value), .groups = "drop") %>% 
   arrange(year) %>% 
@@ -468,10 +471,13 @@ calc_emissions_fraction <- function(data, emissions_data){
 }
 
 # Compute cumulative emissions over time
-emissions <- calc_emissions(trk_output_filtered)
+emissions <- trk_output_filtered %>% 
+  filter(ssp == MAIN_SCENARIO) %>% 
+  calc_emissions() 
 
 # Compute the fraction of fossil fuel emissions residing in the atmosphere
-emissions_fraction <- calc_emissions_fraction(trk_output_filtered, emissions)
+emissions_fraction <- trk_output_filtered %>% filter(ssp == MAIN_SCENARIO) %>%
+  calc_emissions_fraction(emissions)
 
 # Classical definition of AF - find summary stats
 classic_af <- af_results %>%
@@ -505,7 +511,7 @@ ggplot(plot_data, aes(x = year, fill = def)) +
 
 ```{r tracking-multiple-years, warning = FALSE, fig.cap = " Amount of CO2 in the atmosphere sourced from human emissions. Note that turning on tracking in different years does not have a dramatic effect on the composition of the atmosphere pool."}
 # Prepare data: reset the core, set start dates every 50 years
-tcore <- reset(core)
+tcore <- newcore(SSP_files[[MAIN_SCENARIO]])
 dates <- seq(from = 1750, to = 2250, 50)
 tracking_output <- list()
 

--- a/trackingC.Rmd
+++ b/trackingC.Rmd
@@ -589,7 +589,7 @@ hector_temp_runs <- hector_temp %>%
   arrange(ssp, run_number) %>%
   summarize(run_number)
 
-# Filter out data for just the 100 rusn per senario identified above
+# Filter out data for just the 100 runs per scenario identified above
 hector_temp_slice <- left_join(hector_temp_runs, hector_temp, by = c("run_number", "ssp"))
   
 # Plot

--- a/trackingC.Rmd
+++ b/trackingC.Rmd
@@ -226,7 +226,7 @@ plot_data_co2 %>%
 
 ## Atmosphere sources - ƒATM~ffi~
 
-``` {r atmosphere-by-source, fig.cap = " Fraction of CO2 in the atmosphere by source pool from 100 random runs. Dark line shows the median."}
+``` {r atmosphere-by-source, fig.cap = paste0(" Fraction of CO2 in the atmosphere by source pool from 100 random runs in ", MAIN_SCENARIO, ". Dark line shows the median.")}
 # Isolate the atmosphere pool to better understand its composition 
 atmosphere_pool <- trk_output_filtered %>%
   filter(ssp == MAIN_SCENARIO,
@@ -249,7 +249,7 @@ atmosphere_pool %>%
                size = 0.7)
 ```
 
-``` {r earthc-in-atmos, fig.cap = " Fraction of atmospheric CO2 from fossil fuel and industrial (FFI) emissions over time. Line shows median; shaded areas show ±1 s.d. of median (darker) and minimum and maximum of ensemble (lighter)."}
+``` {r earthc-in-atmos, fig.cap = paste0(" Fraction of atmospheric CO2 from fossil fuel and industrial (FFI) emissions over time in ", MAIN_SCENARIO, ". Line shows median; shaded areas show ±1 s.d. of median (darker) and minimum and maximum of ensemble (lighter).")}
 # This chunk looks at the atmosphere pool with just one source (earth_c) 
 # and plots source fraction over time with a confidence interval
 
@@ -323,7 +323,7 @@ ffi_destinations <- trk_output_filtered %>%
   ungroup()
 
 # Just looking at 16 random runs
-dest_runs <- slice_sample(ffi_destinations, n = 10)
+dest_runs <- slice_sample(ffi_destinations, n = 5)
 dest_plot <- filter(ffi_destinations, 
                     run_number %in% dest_runs$run_number & run_number < N_RUNS_SCE)
 
@@ -338,7 +338,7 @@ ggplot(dest_plot, aes(year, destination_fraction, fill = pool_name)) +
        y = "Fraction of FFI emissions")
 ```
 
-```{r relative-importance, message=FALSE, warning=FALSE, fig.cap = " Relative importance of parameters over time in controlling atmosphere as a destination of fossil fuel and industrial (FFI) emissions."}
+```{r relative-importance, message=FALSE, echo=FALSE, warning=FALSE, fig.cap = " Relative importance of parameters over time in controlling atmosphere as a destination of fossil fuel and industrial (FFI) emissions."}
 # Filter to just atmosphere pool, and remove unneeded columns
 dest_e2a <- filter(ffi_destinations, pool_name == "atmos_c")
 dest_e2a_minimal <- dest_e2a[c("year", "destination_fraction", "ssp", names(name_vector))]

--- a/trackingC.Rmd
+++ b/trackingC.Rmd
@@ -390,27 +390,27 @@ ggplot(relimp_out, aes(year, value, fill = param)) +
 # Prep the data
 atm_earth_diffs <- trk_output_filtered %>%
   # Isolate atmosphere and earth total pool values
-  filter(ssp == MAIN_SCENARIO, pool_name %in% c("atmos_c", "earth_c")) %>% 
-  group_by(run_number, year, pool_name) %>% 
+  filter(pool_name %in% c("atmos_c", "earth_c")) %>% 
+  group_by(run_number, year, pool_name, ssp) %>% 
   summarise(pool_value = mean(pool_value), .groups = "drop") %>% 
   arrange(year) %>% 
   # Put atmosphere and earth in separate columns and compute diffs
   pivot_wider(names_from = "pool_name", values_from = "pool_value") %>% 
-  group_by(run_number) %>% 
+  group_by(run_number, ssp) %>% 
   mutate(atm_diff = c(NA, diff(atmos_c)), 
          earth_diff = c(NA, diff(earth_c)))
 
 # Compute AF (classical definition of delta CO2atm / emissions) 
 # using various window sizes
 af_results <- list()
-for (groupsize in seq(1, 40, length.out = 10)) {
+for(groupsize in seq(1, 40, length.out = 10)) {
   ngroups = length(unique(atm_earth_diffs$year)) / groupsize
   
   atm_earth_diffs %>% 
-    group_by(run_number) %>% 
+    group_by(run_number, ssp) %>% 
     mutate(group = cut(year, breaks = ngroups)) %>% 
     # compute differences over the group of years
-    group_by(run_number, group) %>%
+    group_by(run_number, group, ssp) %>%
     summarise(year = max(year), 
               atm_diff = sum(atm_diff), 
               earth_diff = sum(earth_diff), 
@@ -424,10 +424,11 @@ af_results <- bind_rows(af_results, .id = "window_size") %>%
   mutate(window_size = as.integer(window_size))
 
 af_results %>% 
-  group_by(year, window_size) %>% 
+  group_by(year, ssp, window_size) %>% 
   summarise(af = mean(af), .groups = "drop") %>% 
   ggplot(aes(year, af, color = window_size, group = window_size)) + 
   geom_line(na.rm = TRUE) + 
+  facet_wrap(~ssp, scales = "free") +
   labs(x = "Year",
        y = "Airborne fraction")
 
@@ -446,13 +447,16 @@ calc_emissions <- function(data){
          source_name == "earth_c",
          run_number == min(run_number)) %>%
     arrange(year) %>%
+    group_by(ssp) %>%
     # the NA at the end here is so that cumulative emissions 'line up' correctly
     # with the source_quantity (earth-origin atmosphere C) calculated below
     mutate(emissions = -c(diff(pool_value), NA),
            # relative to core$trackingDate
            cumulative_emissions = cumsum(emissions)) %>%
-    select(year, cumulative_emissions)
+    select(year, ssp, cumulative_emissions) %>%
+    arrange(ssp, year)
 }
+
 
 # This function takes a given tracking dataset and its corresponding cumulative 
 # emissions dataset as found above to calculate what fraction of the cumulative
@@ -463,10 +467,10 @@ calc_emissions_fraction <- function(data, emissions_data){
            source_name == "earth_c") %>%
     # How much earth_c is in atmos_c? 
     mutate(source_quantity = pool_value * source_fraction) %>%
-    left_join(emissions_data, by = "year") %>%
-    select(run_number, year, source_quantity, cumulative_emissions) %>%
+    left_join(emissions_data, by = c("year", "ssp")) %>%
+    select(run_number, ssp, year, source_quantity, cumulative_emissions) %>%
     mutate(c_emissions_fraction = source_quantity / cumulative_emissions) %>% 
-    group_by(year) %>%
+    group_by(year, ssp) %>%
     mutate(sdev = sd(c_emissions_fraction),
            med = median(c_emissions_fraction),
            minimum = min(c_emissions_fraction),
@@ -475,17 +479,14 @@ calc_emissions_fraction <- function(data, emissions_data){
 }
 
 # Compute cumulative emissions over time
-emissions <- trk_output_filtered %>% 
-  filter(ssp == MAIN_SCENARIO) %>% 
-  calc_emissions() 
+emissions <- trk_output_filtered %>% calc_emissions() 
 
 # Compute the fraction of fossil fuel emissions residing in the atmosphere
-emissions_fraction <- trk_output_filtered %>% filter(ssp == MAIN_SCENARIO) %>%
-  calc_emissions_fraction(emissions)
+emissions_fraction <- calc_emissions_fraction(trk_output_filtered, emissions)
 
 # Classical definition of AF - find summary stats
 classic_af <- af_results %>%
-  group_by(group, year) %>%
+  group_by(group, year, ssp) %>%
   mutate(sdev = sd(af, na.rm = TRUE),
          minimum = min(af),
          maximum = max(af),
@@ -496,7 +497,7 @@ classic_af <- af_results %>%
 
 # Isolate relevant parameters and plot
 plot_data <- bind_rows(emissions_fraction, classic_af) %>%
-  select(run_number, year, minimum, maximum, med, sdev, def)
+  select(run_number, year, ssp, minimum, maximum, med, sdev, def)
 
 ggplot(plot_data, aes(x = year, fill = def)) +
   geom_ribbon(aes(ymin = minimum, ymax = maximum), 
@@ -506,6 +507,7 @@ ggplot(plot_data, aes(x = year, fill = def)) +
   geom_line(aes(y = med, color = def)) +
   scale_color_viridis_d(begin = 0.5) +
   scale_fill_viridis_d(begin = 0.5) +
+  facet_wrap(~ssp, scales = "free") +
    labs(x = "Year",
         y = "Airborne fraction")
 

--- a/trackingC.Rmd
+++ b/trackingC.Rmd
@@ -104,8 +104,7 @@ cmip_bounds <- cmip_scenarios %>%
 
 hector_temp <- model_output %>%
   filter(variable == "Tgav",
-         year >= 2015 & year <= 2100,
-         run_number <= 100) %>%
+         year >= 2015 & year <= 2100) %>%
   select(run_number, ssp, year, value) %>%
   left_join(cmip_bounds, by = c("year", "ssp")) %>% 
   mutate(fail = value < minimum | value > maximum)
@@ -138,13 +137,13 @@ hector_temp %>%
 ``` {r filtered, fig.cap = "Global temperature anomaly from CMIP6 and filtered Hector runs. Lines show median; shaded areas show ±1 s.d. of median (darker) and minimum and maximum of ensemble (lighter)."}
 # Filter out 'unrealistic' runs (identified above)
 model_output_filtered <- model_output %>%
-  left_join(run_fail_summary, by = "run_number") %>% 
+  left_join(run_fail_summary, by = c("ssp", "run_number")) %>% 
   filter(fraction_fail < 0.5)
 
 # Note that the tracking output needs to be filtered as well
-good_runs <- unique(model_output_filtered$run_number)
 trk_output_filtered <- trk_output %>%
-  filter(run_number %in% good_runs)
+  left_join(run_fail_summary, by = c("ssp", "run_number")) %>% 
+  filter(fraction_fail < 0.5)
   
 # Plot temperature spreads for the filtered runs
 model_output_filtered %>%

--- a/trackingC.Rmd
+++ b/trackingC.Rmd
@@ -528,6 +528,7 @@ set_tracking <- function(c, date){
   run(c, (date + 50))
   tdata <- get_tracking_data(c)
   tdata$ty <- date
+  tdata$ssp <- MAIN_SCENARIO
   tdata
 }
 

--- a/trackingC.Rmd
+++ b/trackingC.Rmd
@@ -122,8 +122,9 @@ run_fail_summary %>%
 
 # ...and a figure 
 hector_temp %>% 
-  left_join(run_fail_summary, by = c("run_number", "ssp")) %>% 
-  filter(run_number <= 100) %>% # this is a debugging figure; plot just 100 runs for clarity
+  left_join(run_fail_summary, by = c("run_number", "ssp")) %>%
+  ### THIS NO LONGER WORKS
+  # filter(run_number <= 100) # this is a debugging figure; plot just 100 runs for clarity
   ggplot(aes(year, value, color = fraction_fail, group = run_number)) + 
   geom_line() + 
   geom_point(aes(y = minimum), color = "black") + 
@@ -322,7 +323,8 @@ ffi_destinations <- trk_output_filtered %>%
   mutate(destination_fraction = source_quantity / sum(source_quantity)) %>% 
   ungroup()
 
-# Just looking at 16 random runs
+# Just looking at 5 random runs across scenarios
+### THIS NO LONGER WORKS
 dest_runs <- slice_sample(ffi_destinations, n = 5)
 dest_plot <- filter(ffi_destinations, 
                     run_number %in% dest_runs$run_number & run_number < N_RUNS_SCE)
@@ -441,6 +443,7 @@ af_results %>%
 # if ever using a scenario with fossil fuel sequestration (atmosphere -> earth)
 
 # This function computes annual cumulative earth_c emissions for a given tracking dataset
+### THIS NO LONGER WORKS
 calc_emissions <- function(data){
   data %>% 
     filter(pool_name == "earth_c",

--- a/trackingC.Rmd
+++ b/trackingC.Rmd
@@ -41,6 +41,14 @@ runlist <- fread("./output_files/runlist.csv")
 model_output <- fread("./output_files/model_output.csv")
 trk_output <- fread("./output_files/trk_output.csv")
 
+# If there are over 100 observations per time point and we want to plot
+# individual runs, we use slice_sample() to randomly select 100 rows.
+
+# Pull random run numbers from the runlist and filter output by random runs
+max_display <- slice_sample(runlist, n = 100)
+trk_output_slice <- filter(trk_output, run_number %in% max_display$run_number)
+model_output_slice <- filter(model_output, run_number %in% max_display$run_number)
+
 ```
 
 # Results
@@ -234,10 +242,6 @@ atmosphere_pool <- trk_output_filtered %>%
          pool_name == "atmos_c")
 
 # This plot looks at source fraction by source pool in the atmosphere and the median run.
-max_display <- runlist %>%
-  filter(ssp == MAIN_SCENARIO) %>%
-  slice_sample(n = 100)
-
 atmosphere_pool %>%
   filter(run_number %in% max_display$run_number) %>%
   ggplot(aes(year, source_fraction, 
@@ -287,7 +291,10 @@ ggplot(atmos_cv, aes(year, cv, group = source_name, color = source_name)) +
   geom_line() +
   scale_color_viridis_d() +
   labs(x = "Source fraction",
-       y = "Coefficient of variability")
+       y = "Coefficient of variability") +
+  xlim(1800, 2300) +
+  ylim(0, 0.25)
+
 ```
 
 ```{r parameter-space, fig.cap = " Parameter correlations and distributions (diagonal), with color indicating how much of the atmosphere is composed of anthropogenic CO2 in the year 2100."}
@@ -338,17 +345,24 @@ dest_runs <- ffi_destinations %>%
 dest_plot <- filter(ffi_destinations, 
                     run_number %in% dest_runs$run_number) 
 
-
 dest_plot %>%
-  ggplot(aes(year, destination_fraction, fill = pool_name)) +
+  group_by(ssp, year, pool_name) %>%
+  mutate(dest_avg = mean(destination_fraction)) %>%
+  filter(run_number == min(run_number)) %>%
+  ggplot(aes(year, dest_avg, fill = pool_name)) +
   geom_area() +
-  scale_fill_viridis_d() +
-  facet_grid(ssp~run_number) +
+  scale_fill_viridis_d(breaks = c("atmos_c", "deep", "detritus_c", "HL", "intermediate",
+                               "LL", "soil_c", "veg_c"),
+                    labels = c("Atmosphere", "Deep ocean", "Detritus",
+                               "High-lat ocean", "Intermed. ocean",
+                               "Low-lat ocean", "Soil", "Vegetation")) +
+  facet_wrap(~ssp) +
   theme(#strip.background = element_blank(),
-        strip.text.x = element_blank(),
+        #strip.text.x = element_blank(),
         axis.text.x = element_text(angle = 90)) +
   labs(x = "Year",
-       y = "Fraction of FFI emissions")
+       y = "Fraction of FFI emissions",
+       fill = "Destination")
 ```
 
 ```{r relative-importance, message=FALSE, echo=FALSE, warning=FALSE, fig.cap = " Relative importance of parameters over time in controlling atmosphere as a destination of fossil fuel and industrial (FFI) emissions."}
@@ -387,14 +401,26 @@ dest_split <- split(dest_e2a_minimal, list(dest_e2a_minimal$year, dest_e2a_minim
 relimp_out <- lapply(dest_split, FUN = calc_relimp) %>% 
   bind_rows()
 
+var_labels <- c("SSP119", "SSP245", "SSP370", "SSP460", "SSP585")
+names(var_labels) <- c("ssp119", "ssp245", "ssp370", "ssp460", "ssp585")
+    
 # ...and plot!
 ggplot(relimp_out, aes(year, value, fill = param)) + 
   geom_area() +
   coord_cartesian(expand = FALSE) +
-  scale_fill_viridis_d(direction = -1) +
-  facet_wrap(~ssp) +
+  scale_fill_viridis_d(direction = -1,
+                       breaks = c("AERO_SCALE", "BETA", "DIFFUSIVITY",
+                                  "ECS", "LUC_SCALE", "NPP_FLUX0", "Q10_RH"),
+                       labels = c("Aerosol forcing", "CO2 fertilization",
+                                  "Ocean diffusivity", "ECS",
+                                  "LUC emissions", "Pre-industrial NPP",
+                                  "Q10")) +
+  facet_wrap(~ssp,
+             labeller = labeller(ssp = var_labels)) +
   labs(x = "Year",
-       y = expression(Relative~importance~"for"~FFI[atm]))
+       y = expression(Relative~importance~"for"~FFI[atm]),
+       fill = "Parameter") +
+  theme(axis.text.x = element_text(angle = 90))
 ```
 
 ## Airborne fraction
@@ -406,10 +432,10 @@ atm_earth_diffs <- trk_output_filtered %>%
   filter(pool_name %in% c("atmos_c", "earth_c")) %>% 
   group_by(run_number, year, pool_name, ssp) %>% 
   summarise(pool_value = mean(pool_value), .groups = "drop") %>% 
-  arrange(year) %>% 
+  arrange(year) %>%
   # Put atmosphere and earth in separate columns and compute diffs
   pivot_wider(names_from = "pool_name", values_from = "pool_value") %>% 
-  group_by(run_number, ssp) %>% 
+  group_by(run_number, ssp) %>%
   mutate(atm_diff = c(NA, diff(atmos_c)), 
          earth_diff = c(NA, diff(earth_c)))
 
@@ -439,11 +465,12 @@ af_results <- bind_rows(af_results, .id = "window_size") %>%
 af_results %>% 
   group_by(year, ssp, window_size) %>% 
   summarise(af = mean(af), .groups = "drop") %>% 
+  filter(year %in% 1900:2200) %>%
   ggplot(aes(year, af, color = window_size, group = window_size)) + 
   geom_line(na.rm = TRUE) + 
   facet_wrap(~ssp, scales = "free") +
   labs(x = "Year",
-       y = "Airborne fraction")
+       y = "Airborne fraction") 
 
 ```
 
@@ -454,7 +481,6 @@ af_results %>%
 # if ever using a scenario with fossil fuel sequestration (atmosphere -> earth)
 
 # This function computes annual cumulative earth_c emissions for a given tracking dataset
-### THIS NO LONGER WORKS
 min_runs <- trk_output_filtered %>%
   group_by(ssp) %>%
   summarize(mrun = min(run_number))
@@ -515,7 +541,8 @@ classic_af <- af_results %>%
 
 # Isolate relevant parameters and plot
 plot_data <- bind_rows(emissions_fraction, classic_af) %>%
-  select(run_number, year, ssp, minimum, maximum, med, sdev, def)
+  select(run_number, year, ssp, minimum, maximum, med, sdev, def) %>%
+  filter(year %in% 1910:2200) # past 2200, data gets weird
 
 ggplot(plot_data, aes(x = year, fill = def)) +
   geom_ribbon(aes(ymin = minimum, ymax = maximum), 
@@ -523,11 +550,20 @@ ggplot(plot_data, aes(x = year, fill = def)) +
   geom_ribbon(aes(ymin = med - sdev, ymax = med + sdev), 
               alpha = 0.4) +
   geom_line(aes(y = med, color = def)) +
-  scale_color_viridis_d(begin = 0.5) +
-  scale_fill_viridis_d(begin = 0.5) +
-  facet_wrap(~ssp, scales = "free") +
-   labs(x = "Year",
-        y = "Airborne fraction")
+  scale_color_viridis_d(begin = 0.5,
+                        breaks = c("ClassicAF", "EmissFraction"),
+                        labels = c("Traditional",
+                                   "Carbon tracking")) +
+  scale_fill_viridis_d(begin = 0.5,
+                        breaks = c("ClassicAF", "EmissFraction"),
+                        labels = c("Traditional",
+                                   "Carbon tracking")) +
+  facet_wrap(~ssp, scales = "free_y", labeller = labeller(ssp = var_labels)) +
+  labs(x = "Year",
+      y = "Airborne fraction",
+      color = "Computation",
+      fill = "Computation") +
+  theme(axis.text.x = element_text(angle = 90))
 
 ```
 

--- a/trackingC.Rmd
+++ b/trackingC.Rmd
@@ -51,7 +51,7 @@ model_output_slice <- filter(model_output, run_number %in% max_display$run_numbe
 
 ```
 
-# Results
+### Results
 
 The following sections contain tentative figures in the order they would appear
 in a manuscript. 
@@ -113,8 +113,8 @@ trk_output_filtered <- trk_output %>%
   filter(fraction_fail < 0.5)
 
 # Create facet labels
-var_labels <- c("SSP119", "SSP245", "SSP370", "SSP460", "SSP585")
-names(var_labels) <- c("ssp119", "ssp245", "ssp370", "ssp460", "ssp585")
+ssp_labels <- c("SSP119", "SSP245", "SSP370", "SSP460", "SSP585")
+names(ssp_labels) <- c("ssp119", "ssp245", "ssp370", "ssp460", "ssp585")
 
 # Plot temperature spreads for the filtered runs
 model_output_filtered %>%
@@ -137,7 +137,7 @@ model_output_filtered %>%
   scale_color_viridis_d(begin = 0.5) +
   scale_fill_viridis_d(begin = 0.5) +
   facet_wrap(~ssp, scales = "free",
-             labeller = labeller(ssp = var_labels)) +
+             labeller = labeller(ssp = ssp_labels)) +
   #theme(legend.title = element_blank()) +
   labs(x = "Year",
        y = expression(degree*C),
@@ -156,6 +156,7 @@ noaa_co2 <- noaa %>%
   mutate(source = "NOAA") %>%
   filter(year < 2015)
 
+# Read in CMIP CO2 data, compute summary statistics
 cmip_c <- read.csv("./data_files/CMIP6_annual_co2.csv")
 cmip_co2 <- cmip_c %>%
   filter(year %in% 1959:2021,
@@ -170,6 +171,7 @@ cmip_co2 <- cmip_c %>%
             source = "CMIP6",
             .groups = "drop")
 
+# Read in Hector data, compute summary statistics 
 hector_co2 <- model_output_filtered %>%
   filter(variable == "Ca",
          year %in% 1959:2021) %>%
@@ -185,6 +187,7 @@ hector_co2 <- model_output_filtered %>%
 
 plot_data_co2 <- bind_rows(cmip_co2, hector_co2)
 
+# Plot
 plot_data_co2 %>% 
   filter(year < 2015) %>%
   ggplot(aes(year, fill = source, color = source)) +
@@ -288,22 +291,27 @@ ffi_destinations <- trk_output_filtered %>%
 ffi_destinations %>%
   filter(ssp == MAIN_SCENARIO) %>%
   group_by(ssp, year, pool_name) %>%
-  mutate(dest_avg = mean(destination_fraction)) %>%
+  mutate(dest_avg = mean(destination_fraction),
+         pool_name = factor(pool_name, levels = rev(c("deep", "intermediate",
+                                                      "LL", "HL", "detritus_c", 
+                                                      "veg_c", "soil_c", "atmos_c")))) %>%
   filter(run_number == min(run_number)) %>%
   ggplot(aes(year, dest_avg, fill = pool_name)) +
   geom_area() +
-  scale_fill_viridis_d(breaks = c("atmos_c", "deep", "detritus_c", "HL", "intermediate",
-                               "LL", "soil_c", "veg_c"),
-                    labels = c("Atmosphere", "Deep ocean", "Detritus",
-                               "High-lat ocean", "Intermed. ocean",
-                               "Low-lat ocean", "Soil", "Vegetation")) +
-  # facet_wrap(~ssp) +
-  #theme(#strip.background = element_blank(),
-        #strip.text.x = element_blank(),
-        #axis.text.x = element_text(angle = 90)) +
+  scale_fill_viridis_d(breaks = c("atmos_c", "soil_c", "veg_c",  "detritus_c", 
+                                  "HL", "LL", "intermediate", "deep" ),
+                       labels = c("Atmosphere", "Soil", "Vegetation",  "Detritus",
+                                  "High-lat ocean", "Low-lat ocean", 
+                                  "Intermed. ocean", "Deep ocean")) +
   labs(x = "Year",
        y = "Fraction of FFI emissions",
        fill = "Destination")
+# These lines are to look at multiple scenarios
+# facet_wrap(~ssp) +
+#theme(#strip.background = element_blank(),
+#strip.text.x = element_blank(),
+#axis.text.x = element_text(angle = 90))
+
 ```
 
 ```{r relative-importance, message=FALSE, echo=FALSE, warning=FALSE, fig.cap = " Relative importance of parameters over time in controlling atmosphere as a destination of fossil fuel and industrial (FFI) emissions."}
@@ -312,8 +320,8 @@ dest_e2a <- filter(ffi_destinations, pool_name == "atmos_c")
 dest_e2a_minimal <- dest_e2a[c("year", "destination_fraction", "ssp", names(name_vector))]
 
 # Function to calculate relative importance of parameters in
-# explaining how much destination_fraction varies for a given
-# year of data. This uses relaimpo::calc.relimp()
+# explaining how much destination_fraction varies for a given year of data. 
+# This uses relaimpo::calc.relimp()
 # See https://www.r-bloggers.com/2012/08/the-relative-importance-of-predictors-let-the-games-begin/
 # for a useful primer, along with the calc.reimp help page
 calc_relimp <- function(x) {
@@ -343,20 +351,25 @@ relimp_out <- lapply(dest_split, FUN = calc_relimp) %>%
   bind_rows()
     
 # ...and plot!
-ggplot(relimp_out, aes(year, value, fill = param)) + 
+relimp_out %>%
+  mutate(param = factor(param, levels = rev(c("NPP_FLUX0", "Q10_RH", "BETA", "ECS", 
+                                       "DIFFUSIVITY", "AERO_SCALE",
+                                       "LUC_SCALE")))) %>%
+  ggplot(aes(year, value, fill = param)) + 
   geom_area() +
   coord_cartesian(expand = FALSE) +
   scale_fill_viridis_d(direction = -1,
-                       breaks = c("AERO_SCALE", "BETA", "DIFFUSIVITY",
-                                  "ECS", "LUC_SCALE", "NPP_FLUX0", "Q10_RH"),
-                       labels = c("Aerosol forcing", "CO2 fertilization",
+                       begin = 0.1,
+                       breaks = c("LUC_SCALE", "AERO_SCALE", "DIFFUSIVITY",
+                                  "ECS", "BETA", "Q10_RH","NPP_FLUX0"),
+                       labels = c("LUC emissions", "Aerosol forcing",
                                   "Ocean diffusivity", "ECS",
-                                  "LUC emissions", "Pre-industrial NPP",
-                                  "Q10")) +
+                                  "CO2 fertilization", "Q10",
+                                   "Pre-industrial NPP")) +
   facet_wrap(~ssp,
-             labeller = labeller(ssp = var_labels)) +
+             labeller = labeller(ssp = ssp_labels)) +
   labs(x = "Year",
-       y = expression(Relative~importance~"for"~FFI[atm]),
+       y = "Relative importance",
        fill = "Parameter") +
   theme(axis.text.x = element_text(angle = 90))
 ```
@@ -402,19 +415,21 @@ all_years_tracking %>%
   filter(source_name == "earth_c", pool_name != "earth_c") %>%
   mutate(source_quantity = pool_value * source_fraction) %>%
   group_by(year) %>%
-  mutate(destination_fraction = source_quantity / sum(source_quantity)) %>% 
+  mutate(destination_fraction = source_quantity / sum(source_quantity))%>% 
   ungroup() %>%
+  mutate(pool_name = factor(pool_name, levels = rev(c("deep", "intermediate",
+                                                      "LL", "HL", "detritus_c",
+                                                      "veg_c", "soil_c", "atmos_co2")))) %>%
   ggplot(aes(year, destination_fraction, fill = pool_name), group = ty) +
   geom_area() +
   labs(x = "Year",
        y = "Destination fraction",
        fill = "Parameter") +
-  scale_fill_viridis_d(breaks = c("atmos_c", "deep", "detritus_c", "HL", "intermediate",
-                               "LL", "soil_c", "veg_c"),
-                    labels = c("Atmosphere", "Deep ocean", "Detritus",
-                               "High-lat ocean", "Intermed. ocean",
-                               "Low-lat ocean", "Soil", "Vegetation"))
-
+  scale_fill_viridis_d(breaks = c("atmos_co2", "soil_c", "veg_c",  "detritus_c",
+                                  "HL", "LL", "intermediate", "deep" ),
+                       labels = c("Atmosphere", "Soil", "Vegetation",  "Detritus",
+                                  "High-lat ocean", "Low-lat ocean",
+                                  "Intermed. ocean", "Deep ocean"))
 ```
 
 ## Airborne fraction
@@ -456,7 +471,6 @@ for(groupsize in seq(1, 40, length.out = 10)) {
 af_results <- bind_rows(af_results, .id = "window_size") %>% 
   mutate(window_size = as.integer(window_size))
 
-
 # Compute cumulative emissions over time
 # We use the change in earth_c to compute emissions; note this will not work
 # if ever using a scenario with fossil fuel sequestration (atmosphere -> earth)
@@ -481,7 +495,6 @@ calc_emissions <- function(data){
     select(year, ssp, cumulative_emissions) %>%
     arrange(ssp, year)
 }
-
 
 # This function takes a given tracking dataset and its corresponding cumulative 
 # emissions dataset as found above to calculate what fraction of the cumulative
@@ -539,7 +552,7 @@ ggplot(plot_data, aes(x = year, fill = def)) +
                         breaks = c("ClassicAF", "EmissFraction"),
                         labels = c("Traditional",
                                    "Carbon tracking")) +
-  facet_wrap(~ssp, scales = "free_y", labeller = labeller(ssp = var_labels)) +
+  facet_wrap(~ssp, scales = "free_y", labeller = labeller(ssp = ssp_labels)) +
   labs(x = "Year",
       y = "Airborne fraction",
       color = "Computation",
@@ -555,6 +568,7 @@ ggplot(plot_data, aes(x = year, fill = def)) +
 
 ``` {r s-params-PDFs, fig.cap = paste0(" Probability densities of each parameter (N=", SSP_runs[[MAIN_SCENARIO]], " draws).")}
 # Density plots to visualize parameter distributions
+# Create facet labels
 param_labels <- c("Aerosol forcing", "CO2 fertilization", "Ocean diffusivity", 
                   "ECS", "LUC emissions", "Pre-industrial NPP", "Q10")
 names(param_labels) <- c("AERO_SCALE", "BETA", "DIFFUSIVITY", "ECS", "LUC_SCALE", 
@@ -599,7 +613,7 @@ left_join(hector_temp_slice, run_fail_summary, by = c("run_number", "ssp")) %>%
   geom_point(aes(y = minimum), color = "black") + 
   geom_point(aes(y = maximum), color = "black") +
   facet_wrap(~ssp,
-             labeller = labeller(ssp = var_labels)) +
+             labeller = labeller(ssp = ssp_labels)) +
   scale_color_viridis_c() +
   labs(x = "Year",
        y = expression(degree*C),
@@ -640,6 +654,11 @@ ggplot(atmos_cv, aes(year, cv, group = source_name, color = source_name)) +
 # Exploring how the parameter space is linked to output
 # What parameters control the percentage of earth_c in the atmosphere?
 # Isolating the year 2100
+pairs_labels <- c("Aerosol", "Beta", "Keff", 
+                  "ECS", "LUC", "NPP", "Q10")
+names(pairs_labels) <- c("AERO_SCALE", "BETA", "DIFFUSIVITY", "ECS", "LUC_SCALE", 
+                         "NPP_FLUX0", "Q10_RH")
+
 ffi_atm_2100 <- atmosphere_pool %>%
   filter(source_name == "earth_c",
          year == 2100) %>% 
@@ -652,7 +671,7 @@ ggpairs(ffi_atm_2100,
         diag = list(mapping = aes(alpha = 0.5)),
         upper = list(continuous = "blank"),
         legend = c(6,5),
-        #columnLabels = param_labels) + 
+        columnLabels = pairs_labels) + 
   scale_color_viridis_d() + 
   scale_fill_viridis_d() +
   labs(color = "Source Fraction")
@@ -669,7 +688,7 @@ af_results %>%
   ggplot(aes(year, af, color = window_size, group = window_size)) + 
   geom_line(na.rm = TRUE) + 
   facet_wrap(~ssp, scales = "free",
-             labeller = labeller(ssp = var_labels)) +
+             labeller = labeller(ssp = ssp_labels)) +
   scale_color_viridis_c() +
   labs(x = "Year",
        y = "Airborne fraction",

--- a/trackingC.Rmd
+++ b/trackingC.Rmd
@@ -60,7 +60,7 @@ in a manuscript.
 
 ## Hector temperature vs. CMIP6 
 
-``` {r filtered, fig.cap = "Global temperature anomaly from CMIP6 and filtered Hector runs. Lines show median; shaded areas show ±1 s.d. of median (darker) and minimum and maximum of ensemble (lighter)."}
+``` {r filtered, warning = FALSE, fig.cap = "Global temperature anomaly from CMIP6 and filtered Hector runs. Lines show median; shaded areas show ±1 s.d. of median (darker) and minimum and maximum of ensemble (lighter)."}
 # Read in CMIP6 comparison data
 cmip_raw <- read.csv("./data_files/CMIP6_annual_tas_global.csv")
 
@@ -210,9 +210,9 @@ atmosphere_pool <- trk_output_filtered %>%
 
 # Create facet labels
 ### FIX THIS
-var_labels_s <- c("atmos_c", "deep", "detritus_c", "HL", "intermediate",
+var_labels_s <- c("atmos_c", "deep", "detritus_c", "earth_c", "HL", "intermediate",
                                "LL", "soil_c", "veg_c")
-names(var_labels_s) <- c("Atmosphere", "Deep ocean", "Detritus",
+names(var_labels_s) <- c("Atmosphere", "Deep ocean", "Detritus", "Anthropogenic emissions",
                                "High-lat ocean", "Intermed. ocean",
                                "Low-lat ocean", "Soil", "Vegetation")
 
@@ -223,8 +223,8 @@ atmosphere_pool %>%
   ggplot(aes(year, source_fraction, 
              color = as.factor(run_number), group = run_number)) +
   geom_line(size = 0.5, show.legend = FALSE) +
-  facet_wrap(~source_name, scales = "free"
-             #labeller = labeller(source_name = var_labels_s)) +
+  facet_wrap(~source_name, scales = "free",
+             labeller = labeller(source_name = var_labels_s)) +
   labs(x = "Year",
        y = "Source fraction") +
   scale_color_grey(start = 0.7, end = 0.7) +
@@ -235,7 +235,7 @@ atmosphere_pool %>%
                size = 0.7)
 ```
 
-``` {r earthc-in-atmos, fig.cap = paste0(" Fraction of atmospheric CO2 from fossil fuel and industrial (FFI) emissions over time in ", MAIN_SCENARIO, ". Line shows median; shaded areas show ±1 s.d. of median (darker) and minimum and maximum of ensemble (lighter).")}
+``` {r earthc-in-atmos, fig.cap = paste0(" Fraction of atmospheric CO2 from fossil fuel and industrial (FFI) emissions over time across scenarios. Line shows median; shaded areas show ±1 s.d. of median (darker) and minimum and maximum of ensemble (lighter).")}
 # This chunk looks at the atmosphere pool with just one source (earth_c) 
 # and plots source fraction over time with a confidence interval
 
@@ -263,7 +263,7 @@ ggplot(ff, aes(year, color = ssp, fill = ssp)) +
 
 ## Destination of FFI emissions - ƒFFI~atm~
 
-```{r destination, fig.cap = " Final destination pools of fossil fuel and industrial (FFI) emissions for 16 random runs."}
+```{r destination, warning = FALSE, fig.cap = paste0(" Final destination pools of fossil fuel and industrial (FFI) emissions averaged over ", SSP_runs[[MAIN_SCENARIO]], " runs in ", MAIN_SCENARIO, ".")}
 # Where does CO2 end up?
 # Step 1: compute source_quantity = pool_value * source_fraction
 # Step 2: for each year and source_name, compute destination_fraction
@@ -365,7 +365,7 @@ ggplot(relimp_out, aes(year, value, fill = param)) +
 
 ## Does time affect destination?
 
-```{r tracking-multiple-years, warning = FALSE, fig.cap = " Amount of CO2 in the atmosphere sourced from human emissions. Note that turning on tracking in different years does not have a dramatic effect on the composition of the atmosphere pool."}
+```{r tracking-multiple-years, warning = FALSE, fig.cap = paste0(" Final destination pools of human emissions in ", MAIN_SCENARIO, ". Note that turning on tracking in different years does not have a dramatic effect on the destination of emissions.")}
 # Prepare data: reset the core, set start dates every 50 years
 tcore <- newcore(SSP_files[[MAIN_SCENARIO]])
 dates <- seq(from = 1750, to = 2250, 50)
@@ -422,31 +422,6 @@ all_years_tracking %>%
 ## Airborne fraction
 
 ```{r airborne, warning = FALSE, fig.cap = " Year-by-year mathematically defined airborne fraction. The yellow line and band shows the actual amount of human emissions remaining in the atmosphere from the model's carbon-tracking mechanism."}
-# Exploring how the parameter space is linked to output
-# What parameters control the percentage of earth_c in the atmosphere?
-# Isolating the year 2100
-
-ffi_atm_2100 <- atmosphere_pool %>%
-  filter(source_name == "earth_c",
-         year == 2100) %>% 
-  mutate(sf = cut(source_fraction, 3))
-
-n <- length(name_vector)
-ggpairs(ffi_atm_2100,
-        columns = 10:(10 + (n-1)),
-        # Color by magnitude of source_fraction - how much earth_c is in the atmosphere
-        aes(color = sf), 
-        diag = list(mapping = aes(alpha = 0.5)),
-        upper = list(continuous = "blank"),
-        legend = c(6,5)) + 
-  scale_color_viridis_d() + 
-  scale_fill_viridis_d() +
-  labs(color = "Source Fraction")
-```
-
-## Airborne fraction time windows
-
-```{r af-windows, fig.cap = " Airborne fraction computed over varying time windows."}
 # Prep the data
 atm_earth_diffs <- trk_output_filtered %>%
   # Isolate atmosphere and earth total pool values
@@ -580,7 +555,7 @@ ggplot(plot_data, aes(x = year, fill = def)) +
 
 ## Realized parameter PDFs
 
-``` {r params-PDFs, fig.cap = paste0(" Probability densities of each parameter (N=", SSP_runs[[MAIN_SCENARIO]], " draws).")}
+``` {r s-params-PDFs, fig.cap = paste0(" Probability densities of each parameter (N=", SSP_runs[[MAIN_SCENARIO]], " draws).")}
 # Density plots to visualize parameter distributions
 runlist %>% 
   filter(ssp == MAIN_SCENARIO) %>%
@@ -594,7 +569,7 @@ runlist %>%
 
 ## Hector temperature vs CMIP6 diagnostic
 
-``` {r cmip, message = FALSE, fig.cap = " Visualization of sample model runs. The black dots represent the CMIP6 minimums and maximums for global temperature anomaly, and the runs that pass must fall within these bounds more than 50% of the time."}
+``` {r s-cmip, message = FALSE, fig.cap = " Visualization of sample model runs. The black dots represent the CMIP6 minimums and maximums for global temperature anomaly, and the runs that pass must fall within these bounds more than 50% of the time."}
 # Visualize the run fail summary calculated above
 # Make a table of failure rates
 run_fail_summary %>% 
@@ -630,7 +605,7 @@ left_join(hector_temp_slice, run_fail_summary, by = c("run_number", "ssp")) %>%
 
 ## Source coefficients of variability
 
-``` {r coeff-var, fig.cap = " Coefficients of variability for each source in the atmosphere over time."}
+``` {r s-coeff-var, fig.cap = " Coefficients of variability for each source in the atmosphere over time."}
 # Compute coefficient of variability for each source in the atmosphere pool
 atmos_cv <- atmosphere_pool %>%
   filter(ssp == MAIN_SCENARIO) %>%
@@ -657,7 +632,7 @@ ggplot(atmos_cv, aes(year, cv, group = source_name, color = source_name)) +
 
 ## Parameter distributions and source fraction controls
 
-```{r parameter-space, fig.cap = " Parameter correlations and distributions (diagonal), with color indicating how much of the atmosphere is composed of anthropogenic CO2 in the year 2100."}
+```{r s-parameter-space, fig.cap = " Parameter correlations and distributions (diagonal), with color indicating how much of the atmosphere is composed of anthropogenic CO2 in the year 2100."}
 # Exploring how the parameter space is linked to output
 # What parameters control the percentage of earth_c in the atmosphere?
 # Isolating the year 2100
@@ -680,7 +655,7 @@ ggpairs(ffi_atm_2100,
 
 # Airborne fraction window size
 
-```{r parameter-space, fig.cap = " Parameter correlations and distributions (diagonal), with color indicating how much of the atmosphere is composed of anthropogenic CO2 in the year 2100."}
+```{r s-af-window, fig.cap = " Parameter correlations and distributions (diagonal), with color indicating how much of the atmosphere is composed of anthropogenic CO2 in the year 2100."}
 # Plot airborne fraction window size plot
 af_results %>% 
   group_by(year, ssp, window_size) %>% 
@@ -699,7 +674,7 @@ af_results %>%
 
 ## Tracking year plus one (work in progress)
 
-``` {r tracking-af}
+``` {r s-tracking-af}
 # We want to calculate airborne fraction in the year immediately following the 
 # tracking date. 
 date_plus_one <- dates + 1

--- a/trackingC_common.R
+++ b/trackingC_common.R
@@ -3,11 +3,11 @@
 library(hector)
 
 # Number of runs for each SSP scenario
-SSP_runs <- c("ssp119" = 300,
-              "ssp370" = 300,
-              "ssp245" = 500,
-              "ssp460" = 300,
-              "ssp585" = 300)
+SSP_runs <- c("ssp119" = 500,
+              "ssp370" = 500,
+              "ssp245" = 700,
+              "ssp460" = 500,
+              "ssp585" = 500)
 
 # We use GitHub Actions to make sure this RMarkdown knits successfully
 # But if running there, only do a small number of Hector simulations
@@ -21,7 +21,7 @@ names(SSP_files) <- names(SSP_runs)
 MAIN_SCENARIO <- "ssp245"
 
 # Set range of years for output data
-OUTPUT_YEARS <- 1950:2200
+OUTPUT_YEARS <- 1750:2300
 
 # Define name and units of all parameters
 name_vector <- c("BETA" = BETA(),

--- a/trackingC_common.R
+++ b/trackingC_common.R
@@ -1,17 +1,26 @@
 
 # Settings used by both trackingC_setup.Rmd and trackingC.Rmd
 
-# Read in ini file, initiate new core
-ssp245 <- system.file("input/hector_ssp245.ini", package = "hector") 
-core <- newcore(ssp245)
+# # Read in ini file, initiate new core
+# ssp245 <- system.file("input/hector_ssp245.ini", package = "hector") 
+# core <- newcore(ssp245)
 
 # Extract and LUC emissions data for later multiplication by LUC_SCALAR
-run(core)
-luc <- fetchvars(core, core$strtdate:core$enddate, LUC_EMISSIONS())
+# run(core)
+# luc <- fetchvars(core, core$strtdate:core$enddate, LUC_EMISSIONS())
 
+SSP_files <- c("SSP119" = system.file("input/hector_ssp119.ini", package = "hector"),
+               "SSP245" = system.file("input/hector_ssp245.ini", package = "hector"),
+               "SSP585" = system.file("input/hector_ssp585.ini", package = "hector"))
 
 # Number of model runs to perform
-N_RUNS <- 1000
+N_RUNS <- c(
+  "SSP119" = 100,
+  "SSP245" = 100,
+  "SSP585" = 100
+)
+
+MAIN_SCENARIO <- "SSP245"
 
 # We use GitHub Actions to make sure this RMarkdown knits successfully
 # But if running there, only do a small number of Hector simulations
@@ -26,13 +35,13 @@ OUTPUT_YEARS <- 1950:2200
 name_vector <- c("BETA" = BETA(), "Q10_RH" = Q10_RH(), 
                  "ECS" = ECS(), "NPP_FLUX0" = NPP_FLUX0(),
                  "AERO_SCALE" = AERO_SCALE(), "DIFFUSIVITY" = DIFFUSIVITY(),
-                 "LUC_SCALAR" = "LUC_SCALAR"
+                 "LUC_SCALE" = "LUC_SCALE"
 )
 
 units_vector <- c("BETA" = "(unitless)", "Q10_RH" = "(unitless)", 
                   "ECS" = "degC", "NPP_FLUX0" = "Pg C/yr",
                   "AERO_SCALE" = "(unitless)", "DIFFUSIVITY" = "cm2/s",
-                  "LUC_SCALAR" = "(unitless)"
+                  "LUC_SCALE" = "(unitless)"
 )
 
-scalar_vector <- "LUC_SCALAR"
+scalar_vector <- "LUC_SCALE"

--- a/trackingC_common.R
+++ b/trackingC_common.R
@@ -15,6 +15,9 @@ SSP_files <- c("ssp119" = system.file("input/hector_ssp119.ini", package = "hect
 
 MAIN_SCENARIO <- "ssp245"
 
+N_RUNS_SCE <- 100
+N_RUNS_MAIN <- 500
+
 # We use GitHub Actions to make sure this RMarkdown knits successfully
 # But if running there, only do a small number of Hector simulations
 if(Sys.getenv("CI") == "true") {

--- a/trackingC_common.R
+++ b/trackingC_common.R
@@ -5,13 +5,13 @@ library(hector)
 # Number of runs for each SSP scenario
 SSP_runs <- c("ssp119" = 500,
               "ssp370" = 500,
-              "ssp245" = 700,
+              "ssp245" = 1000,
               "ssp460" = 500,
               "ssp585" = 500)
 
 # We use GitHub Actions to make sure this RMarkdown knits successfully
 # But if running there, only do a small number of Hector simulations
-# Set to a maximum of 100 runs per scenario - some code chunks needs at least 100 runs
+# Set to a maximum of 100 runs per scenario - some code chunks need at least 100 runs
 if(Sys.getenv("CI") == "true") {
   SSP_runs[SSP_runs > 100] <- 100  
 }

--- a/trackingC_common.R
+++ b/trackingC_common.R
@@ -12,7 +12,7 @@ SSP_runs <- c("ssp119" = 500,
 # We use GitHub Actions to make sure this RMarkdown knits successfully
 # But if running there, only do a small number of Hector simulations
 if(Sys.getenv("CI") == "true") {
-  SSP_runs <- rep(20, length(SSP_runs))
+  SSP_runs[SSP_runs > 20] <- 20  # set to a maximum of 20 runs per scenario
 }
 
 SSP_files <- system.file(paste0("input/hector_", names(SSP_runs), ".ini"), package = "hector")

--- a/trackingC_common.R
+++ b/trackingC_common.R
@@ -15,8 +15,8 @@ SSP_files <- c("ssp119" = system.file("input/hector_ssp119.ini", package = "hect
 
 MAIN_SCENARIO <- "ssp245"
 
-N_RUNS_SCE <- 100
-N_RUNS_MAIN <- 500
+N_RUNS_SCE <- 500
+N_RUNS_MAIN <- 1000
 
 # We use GitHub Actions to make sure this RMarkdown knits successfully
 # But if running there, only do a small number of Hector simulations

--- a/trackingC_common.R
+++ b/trackingC_common.R
@@ -13,13 +13,6 @@ SSP_files <- c("SSP119" = system.file("input/hector_ssp119.ini", package = "hect
                "SSP245" = system.file("input/hector_ssp245.ini", package = "hector"),
                "SSP585" = system.file("input/hector_ssp585.ini", package = "hector"))
 
-# Number of model runs to perform
-N_RUNS <- c(
-  "SSP119" = 100,
-  "SSP245" = 100,
-  "SSP585" = 100
-)
-
 MAIN_SCENARIO <- "SSP245"
 
 # We use GitHub Actions to make sure this RMarkdown knits successfully

--- a/trackingC_common.R
+++ b/trackingC_common.R
@@ -9,11 +9,11 @@
 # run(core)
 # luc <- fetchvars(core, core$strtdate:core$enddate, LUC_EMISSIONS())
 
-SSP_files <- c("SSP119" = system.file("input/hector_ssp119.ini", package = "hector"),
-               "SSP245" = system.file("input/hector_ssp245.ini", package = "hector"),
-               "SSP585" = system.file("input/hector_ssp585.ini", package = "hector"))
+SSP_files <- c("ssp119" = system.file("input/hector_ssp119.ini", package = "hector"),
+               "ssp245" = system.file("input/hector_ssp245.ini", package = "hector"),
+               "ssp585" = system.file("input/hector_ssp585.ini", package = "hector"))
 
-MAIN_SCENARIO <- "SSP245"
+MAIN_SCENARIO <- "ssp245"
 
 # We use GitHub Actions to make sure this RMarkdown knits successfully
 # But if running there, only do a small number of Hector simulations

--- a/trackingC_common.R
+++ b/trackingC_common.R
@@ -3,9 +3,11 @@
 library(hector)
 
 # Number of runs for each SSP scenario
-SSP_runs <- c("ssp119" = 100,
+SSP_runs <- c("ssp119" = 300,
+              "ssp370" = 300,
               "ssp245" = 500,
-              "ssp585" = 100)
+              "ssp460" = 300,
+              "ssp585" = 300)
 
 # We use GitHub Actions to make sure this RMarkdown knits successfully
 # But if running there, only do a small number of Hector simulations

--- a/trackingC_common.R
+++ b/trackingC_common.R
@@ -11,8 +11,9 @@ SSP_runs <- c("ssp119" = 500,
 
 # We use GitHub Actions to make sure this RMarkdown knits successfully
 # But if running there, only do a small number of Hector simulations
+# Set to a maximum of 100 runs per scenario - some code chunks needs at least 100 runs
 if(Sys.getenv("CI") == "true") {
-  SSP_runs[SSP_runs > 20] <- 20  # set to a maximum of 20 runs per scenario
+  SSP_runs[SSP_runs > 100] <- 100  
 }
 
 SSP_files <- system.file(paste0("input/hector_", names(SSP_runs), ".ini"), package = "hector")

--- a/trackingC_setup.Rmd
+++ b/trackingC_setup.Rmd
@@ -188,7 +188,7 @@ runlist_scenario <- left_join(runlist_sce, param_sce, by = "run_number")
 
 # Next, create a dataframe for just the main scenario, SSP
 # This will include the first 100 runs from the scenario runlist, above
-N_RUNS_MAIN <- 200
+N_RUNS_MAIN <- 500
 runlist_ma <- tibble(
   # Creates a sequence from one above the number of scenario runs to the
   # number of main runs, eg 101 to 1000
@@ -279,7 +279,7 @@ tibble(lognorm = ecs_vals_lognorm, transformed = just_ECS$ECS) %>%
 Run the model and store outputs and tracking data.
 
 ```{r functions, cache=TRUE, message=FALSE}
-run_hector <- function(pdata, c) {
+run_hector <- function(pdata, c, sce) {
   
   # Function to set multiple parameter values for Hector, run a core, and retrieve tracking data
   # pdata will be the runlist specified above
@@ -307,6 +307,9 @@ run_hector <- function(pdata, c) {
            # to keep file size down
            source_name == "earth_c" | pool_name == "atmos_c")
   out$results <- fetchvars(c, OUTPUT_YEARS, c("Ca", "Ftot", "FCO2", "Tgav", "luc_emissions"))
+  
+  out$results$ssp <- sce
+  out$tdata$ssp <- sce
   return(out)
 }
 
@@ -323,22 +326,35 @@ errors <- list()
 
 # Record start time 
 start_time <- Sys.time()
+
 for(s in names(SSP_files)) {
   # Filter runlist by scenario
   s_runlist <- runlist %>% filter(ssp == s)
-  core <- newcore(SSP_files[s])
-  # Extract and LUC emissions data for later multiplication by LUC_SCALE
+  # Initiate new core, by scenario
+  core <- newcore(SSP_files[[s]])
+  # Run core, extract LUC emissions data for later multiplication by LUC_SCALE
   run(core)
-  # luc <- fetchvars(core, core$strtdate:core$enddate, LUC_EMISSIONS())
+  luc <- fetchvars(core, core$strtdate:core$enddate, LUC_EMISSIONS())
+  
   for(row in seq_len(nrow(s_runlist))) {
     message(row, "/", nrow(s_runlist))
-    outp <- try(run_hector(s_runlist[row,][-c(1,2)], core))
+    outp <- try(run_hector(s_runlist[row,][-c(1,2)], core, s))
     if(class(outp) == "try-error") { 
       # if there is an error, record row numbers that error
       errors[[row]] <- s_runlist$run_number[[row]]
     } else {
-      out[[s_runlist$run_number[row]]] <- outp
-    }}  
+      # Create unique ssp + run_number identifier for each row so that data 
+      # does not get overwritten
+      id <- paste0(s, "_", row)
+      # Save output by id
+      out[[id]] <- outp
+      # Add in run_number column - can no longer bind_rows() by run_number
+      # because data is grouped by id
+      out[[id]]$results$run_number <- s_runlist$run_number[[row]]
+      out[[id]]$tdata$run_number <- s_runlist$run_number[[row]]
+    }
+  }
+  shutdown(core)
 }
 
 # Compute difference in time between start and after loop is run
@@ -364,24 +380,24 @@ tdata <- list()
 for(n in seq_len(length(out))){
   tdata[[n]] <- out[[n]]$tdata
 }
-trk_output <- bind_rows(tdata, .id = "run_number") %>% as_tibble
+trk_output <- bind_rows(tdata, .id = "delete_me") %>% as_tibble
 
 # Then, access model output data
 results <- list()
 for(n in seq_len(length(out))){
   results[[n]] <- out[[n]]$results
 }
-model_output <- bind_rows(results, .id = "run_number") %>% as_tibble()
+model_output <- bind_rows(results, .id = "delete_me") %>% as_tibble()
 
 # Can left join with runlist to get param values
 # Make sure data is same class
 trk_output$run_number <- as.integer(trk_output$run_number)
-trk_output <- left_join(trk_output, runlist, by = "run_number") %>%
-  arrange(ssp, run_number)
+trk_output <- left_join(trk_output, runlist, by = c("run_number", "ssp")) %>%
+  select(-delete_me)
 
 model_output$run_number <- as.integer(model_output$run_number)
-model_output <- left_join(model_output, runlist, by = "run_number") %>%
-  arrange(ssp, run_number)
+model_output <- left_join(model_output, runlist, by = c("run_number", "ssp")) %>%
+  select(-delete_me)
 
 ```
 

--- a/trackingC_setup.Rmd
+++ b/trackingC_setup.Rmd
@@ -136,24 +136,21 @@ lognorm <- function(m, sd){
   v <- c(mn, stdev)
 }
 
-# Runlist contains run number, parameter, and a random distribution
-run <- list()
-for(s in names(SSP_files)){
- run[[s]] <- data.frame(
-    scenario = rep(s, times = N_RUNS[s]),
-    run_number = 1:N_RUNS[s],
-    
+N_RUNS_SCE <- 100
+params <- function(runs){
+  tibble(
+    run_number = 1:runs,
     # Keenan et al. (2021) (0.54, 0.03)
-    "BETA" = rnorm(N_RUNS[s], mean = 0.5, sd = 0.1),
+    "BETA" = rnorm(runs, mean = 0.5, sd = 0.1),
     
     # Davidson and Janssens (2006)
-    "Q10_RH" = rlnorm(N_RUNS[s], lognorm(2, 1.0)[1], lognorm(2, 1.0)[2]),
+    "Q10_RH" = rlnorm(runs, lognorm(2, 1.0)[1], lognorm(2, 1.0)[2]),
     
     # Ito (2011)
-    "NPP_FLUX0" = rnorm(N_RUNS[s], mean = 56.2, sd = 14.3),
+    "NPP_FLUX0" = rnorm(runs, mean = 56.2, sd = 14.3),
     
     # Hector default
-    "AERO_SCALE" = rnorm(N_RUNS[s], mean = 1.0, sd = 0.1),
+    "AERO_SCALE" = rnorm(runs, mean = 1.0, sd = 0.1),
     
     # Land use change emissions scaling parameter, to account for uncertainties in values for LUC
     # Friedlingstein et al 2021 state: 
@@ -167,11 +164,34 @@ for(s in names(SSP_files)){
     # Or, 0.83 < x < 1.61 
     # The following distribution roughly aligns with the above criteria
     # Using a lognormal distribution because we do not want negative or near-zero values
-    "LUC_SCALE" = rlnorm(N_RUNS[s], lognorm(1.3, 0.2)[1], lognorm(1.3, 0.2)[2])
+    "LUC_SCALE" = rlnorm(runs, lognorm(1.3, 0.2)[1], lognorm(1.3, 0.2)[2])
   )
 }
 
-runlist <- bind_rows(run)
+run <- list()
+for(s in names(SSP_files)){
+ run[[s]] <- data.frame(
+   run_number = 1:N_RUNS_SCE,
+   scenario = rep(s, times = N_RUNS_SCE)
+ )}
+
+runlist_sce <- bind_rows(run)
+param_sce <- params(N_RUNS_SCE)
+
+runlist_scenario <- left_join(runlist_sce, param_sce, by = "run_number")
+
+N_RUNS_MAIN <- 9999
+runlist_ma <- tibble(
+  run_number = (1 + N_RUNS_SCE:N_RUNS_MAIN),
+  scenario = rep("SSP245", times = length(run_number))
+)
+
+param_main <- params(nrow(runlist_ma))
+runlist_mai <- left_join(runlist_ma, param_main, by = "run_number")
+
+runlist_main <- runlist_scenario %>%
+  filter(scenario == "SSP245") %>%
+  bind_rows(runlist_mai)
 
 ```
 

--- a/trackingC_setup.Rmd
+++ b/trackingC_setup.Rmd
@@ -136,7 +136,7 @@ lognorm <- function(m, sd){
   v <- c(mn, stdev)
 }
 
-N_RUNS_SCE <- 100
+# Function to create a tibble of random draws given a specified number to produce
 params <- function(runs){
   tibble(
     run_number = 1:runs,
@@ -168,27 +168,38 @@ params <- function(runs){
   )
 }
 
+# Create a runlist of 100 runs for each SSP
+# First, create run_number and scenario identifier columns
+N_RUNS_SCE <- 100
+
 run <- list()
 for(s in names(SSP_files)){
  run[[s]] <- data.frame(
    run_number = 1:N_RUNS_SCE,
    scenario = rep(s, times = N_RUNS_SCE)
  )}
-
 runlist_sce <- bind_rows(run)
+
+# Next, create a parameter dataframe using the params() function, above
 param_sce <- params(N_RUNS_SCE)
 
+# Join the data
 runlist_scenario <- left_join(runlist_sce, param_sce, by = "run_number")
 
-N_RUNS_MAIN <- 9999
+# Next, create a dataframe for just the main scenario, SSP
+# This will include the first 100 runs from the scenario runlist, above
+# So, if we want 1,000 runs, we need to pass in one less
+N_RUNS_MAIN <- 1000
 runlist_ma <- tibble(
-  run_number = (1 + N_RUNS_SCE:N_RUNS_MAIN),
+  run_number = (1 + N_RUNS_SCE:(N_RUNS_MAIN-1)),
   scenario = rep("SSP245", times = length(run_number))
 )
 
+# Create parameter dataset and combine with run number and scenario
 param_main <- params(nrow(runlist_ma))
 runlist_mai <- left_join(runlist_ma, param_main, by = "run_number")
 
+# Now, combine the first 100 runs from runlist_scenario to get a final, main scenario runlist
 runlist_main <- runlist_scenario %>%
   filter(scenario == "SSP245") %>%
   bind_rows(runlist_mai)
@@ -197,11 +208,12 @@ runlist_main <- runlist_scenario %>%
 
 ``` {r joint-params, fig.cap = " The final joint distribution of ECS and diffusivity. The individual parameter distributions are shown on the x and y axes."}
 # Joint PDF for ECS and diffusivity
+# Use N_RUNS_MAIN and down sort later
 # Sherwood et al (2020)
-ecs_vals_lognorm <- rlnorm(N_RUNS, lognorm(3.25, 0.65)[1], lognorm(3.25, 0.65)[2])
+ecs_vals_lognorm <- rlnorm(N_RUNS_MAIN, lognorm(3.25, 0.65)[1], lognorm(3.25, 0.65)[2])
 # Transform ECS distribution to log(distribution)
 ecs_vals_to_norm <- log(ecs_vals_lognorm)
-diffusion_vals <- rnorm(N_RUNS, mean = 2.3, sd = 0.23)
+diffusion_vals <- rnorm(N_RUNS_MAIN, mean = 2.3, sd = 0.23)
 
 DESIRED_PCOR <- -0.75  # ECS and diffusivity should be negatively correlated
 # https://en.wikipedia.org/wiki/Covariance_and_correlation
@@ -216,7 +228,7 @@ Sigma <- matrix(c(var(ecs_vals_to_norm),
                 2, 2)
 # ...and generate values--twice as many as needed because we toss out
 # negative ECS values below (see note above)
-joint_vals <- MASS::mvrnorm(n = N_RUNS * 2, c(mean(ecs_vals_to_norm), mean(diffusion_vals)), Sigma)
+joint_vals <- MASS::mvrnorm(n = N_RUNS_MAIN * 2, c(mean(ecs_vals_to_norm), mean(diffusion_vals)), Sigma)
 jv <- as_tibble(joint_vals)
 colnames(jv) <- c("ECS", "DIFFUSIVITY")
 
@@ -224,9 +236,16 @@ colnames(jv) <- c("ECS", "DIFFUSIVITY")
 jv %>% 
   mutate(ECS = exp(ECS)) %>%
   filter(ECS > 0) %>% 
-  sample_n(N_RUNS) %>%
-  bind_cols(runlist, .) ->
+  sample_n(N_RUNS_MAIN) %>%
+  bind_cols(runlist_main, .) ->
   runlist
+
+# Down sort to the first 100 runs and bind to the scenario runlist
+small_runlist <- runlist %>%
+  filter(run_number %in% 1:100) %>%
+  select(run_number, ECS, DIFFUSIVITY)
+
+runlist_scenario <- left_join(runlist_scenario, small_runlist, by = "run_number")
 
 # Visualize the final joint distribution of ECS and DIFFUSIVITY
 p <- ggplot(runlist, aes(ECS, DIFFUSIVITY)) + 

--- a/trackingC_setup.Rmd
+++ b/trackingC_setup.Rmd
@@ -137,35 +137,41 @@ lognorm <- function(m, sd){
 }
 
 # Runlist contains run number, parameter, and a random distribution
-runlist <- tibble(
-  run_number = 1:N_RUNS,
-  # Keenan et al. (2021) (0.54, 0.03)
-  "BETA" = rnorm(N_RUNS, mean = 0.5, sd = 0.1),
-  
-  # Davidson and Janssens (2006)
-  "Q10_RH" = rlnorm(N_RUNS, lognorm(2, 1.0)[1], lognorm(2, 1.0)[2]),
-  
-  # Ito (2011)
-  "NPP_FLUX0" = rnorm(N_RUNS, mean = 56.2, sd = 14.3),
-  
-  # Hector default
-  "AERO_SCALE" = rnorm(N_RUNS, mean = 1.0, sd = 0.1),
-  
-  # Land use change emissions scaling parameter, to account for uncertainties in values for LUC
-  # Friedlingstein et al 2021 state: 
-  # Cumulative CO2 emissions from land-use changes (ELUC) for 1850-2020 were 200 ± 65 GtC...
-  # ...large spread among individual estimates of 140 GtC (updated H&N2017), 270 GtC (BLUE),
-  # and 195 GtC (OSCAR) for the three bookkeeping models and a similar wide estimate of 190 ± 60 GtC for the DGVMs
-  # Cumulative LUC_EMISSIONS() in Hector from 1850 to 2020 total 168 GtC
-  # We want to create a random distribution to scale our Hector emissions
-  # to account for the large uncertainties
-  # Our bounds for a reasonable scalar therefore are (270/168) and (140/168)
-  # Or, 0.83 < x < 1.61 
-  # The following distribution roughly aligns with the above criteria
-  # Using a lognormal distribution because we do not want negative or near-zero values
-  "LUC_SCALAR" = rlnorm(N_RUNS, lognorm(1.3, 0.2)[1], lognorm(1.3, 0.2)[2])
-)
+run <- list()
+for(s in names(SSP_files)){
+ run[[s]] <- data.frame(
+    scenario = rep(s, times = N_RUNS[s]),
+    run_number = 1:N_RUNS[s],
+    
+    # Keenan et al. (2021) (0.54, 0.03)
+    "BETA" = rnorm(N_RUNS[s], mean = 0.5, sd = 0.1),
+    
+    # Davidson and Janssens (2006)
+    "Q10_RH" = rlnorm(N_RUNS[s], lognorm(2, 1.0)[1], lognorm(2, 1.0)[2]),
+    
+    # Ito (2011)
+    "NPP_FLUX0" = rnorm(N_RUNS[s], mean = 56.2, sd = 14.3),
+    
+    # Hector default
+    "AERO_SCALE" = rnorm(N_RUNS[s], mean = 1.0, sd = 0.1),
+    
+    # Land use change emissions scaling parameter, to account for uncertainties in values for LUC
+    # Friedlingstein et al 2021 state: 
+    # Cumulative CO2 emissions from land-use changes (ELUC) for 1850-2020 were 200 ± 65 GtC...
+    # ...large spread among individual estimates of 140 GtC (updated H&N2017), 270 GtC (BLUE),
+    # and 195 GtC (OSCAR) for the three bookkeeping models and a similar wide estimate of 190 ± 60 GtC for the DGVMs
+    # Cumulative LUC_EMISSIONS() in Hector from 1850 to 2020 total 168 GtC
+    # We want to create a random distribution to scale our Hector emissions
+    # to account for the large uncertainties
+    # Our bounds for a reasonable scalar therefore are (270/168) and (140/168)
+    # Or, 0.83 < x < 1.61 
+    # The following distribution roughly aligns with the above criteria
+    # Using a lognormal distribution because we do not want negative or near-zero values
+    "LUC_SCALE" = rlnorm(N_RUNS[s], lognorm(1.3, 0.2)[1], lognorm(1.3, 0.2)[2])
+  )
+}
 
+runlist <- bind_rows(run)
 
 ```
 

--- a/trackingC_setup.Rmd
+++ b/trackingC_setup.Rmd
@@ -207,8 +207,8 @@ Sigma <- matrix(c(var(ecs_vals_to_norm),
 joint_vals <- MASS::mvrnorm(n = nrow(runlist) * 2,
                             c(mean(ecs_vals_to_norm),
                               mean(diffusion_vals)), Sigma)
+colnames(joint_vals) <- c("ECS", "DIFFUSIVITY")
 jv <- as_tibble(joint_vals)
-colnames(jv) <- c("ECS", "DIFFUSIVITY")
 
 # Filter and bind to the runlist
 jv %>% 
@@ -336,6 +336,10 @@ Doing `r nrow(runlist)` runs took `r tm` seconds or `r tm/(sum(SSP_runs[1:5]))` 
 Get lists from above into nice dataframes.
 
 ``` {r data}
+if(!length(out)) {
+  stop("No output data; probably no model runs were done because cache=TRUE")  
+}
+
 # Get output data frames
 # First, access tracking data
 tdata <- list()

--- a/trackingC_setup.Rmd
+++ b/trackingC_setup.Rmd
@@ -112,7 +112,7 @@ set.seed(10)
 
 Currently, we are looking at seven Hector parameters: `BETA(), Q10_RH(), ECS(),
 NPP_FLUX0(), AERO_SCALE(), DIFFUSIVITY(), and a LUC emissions scalar`. 
-We created a runlist with `r # SSP_runs[[MAIN_SCENARIO]]` random
+We created a runlist with `r SSP_runs[MAIN_SCENARIO]` random
 draws in a normal (or lognormal, where applicable) distribution.
 
 ECS (equilibrium climate sensitivity) and ocean heat diffusivity are 
@@ -173,7 +173,7 @@ generate_params <- function(run_numbers){
 # Create a single runlist for all SSPs
 # First create scenario identifier column (across all scenarios) using 
 # mapply, and then generate the run numbers 
-scenarios <- mapply(rep, names(SSP_runs), SSP_runs) %>% unlist()
+scenarios <- mapply(rep, names(SSP_runs), SSP_runs) %>% as.vector()
 runlist <- tibble(run_number = seq_along(scenarios), ssp = scenarios)
 
 # Next, create and join a parameter dataframe

--- a/trackingC_setup.Rmd
+++ b/trackingC_setup.Rmd
@@ -170,8 +170,6 @@ params <- function(runs){
 
 # Create a runlist of 100 runs for each SSP
 # First, create run_number and scenario identifier columns
-N_RUNS_SCE <- 100
-
 run <- list()
 for(s in names(SSP_files)){
  run[[s]] <- data.frame(
@@ -188,7 +186,6 @@ runlist_scenario <- left_join(runlist_sce, param_sce, by = "run_number")
 
 # Next, create a dataframe for just the main scenario, SSP
 # This will include the first 100 runs from the scenario runlist, above
-N_RUNS_MAIN <- 500
 runlist_ma <- tibble(
   # Creates a sequence from one above the number of scenario runs to the
   # number of main runs, eg 101 to 1000
@@ -251,7 +248,7 @@ runlist_scenario <- left_join(runlist_scenario, small_runlist, by = "run_number"
 
 # Combine runlists
 runlist <- runlist_scenario %>%
-  filter(ssp != "ssp245") %>%
+  filter(ssp != MAIN_SCENARIO) %>%
   bind_rows(runlist_main)
 
 # Visualize the final joint distribution of ECS and DIFFUSIVITY
@@ -266,7 +263,7 @@ ggExtra::ggMarginal(p, type = "histogram", alpha = 0.2)
 ``` {r log-dist, fig.cap = " Comparing the original, random, lognormal distribution for ECS with the final transformed version, the exponential of the log of ECS."}
 
 # Visualize proper lognormal versus transformed distributions for ECS
-just_ECS <- filter(runlist, ssp == "ssp245")
+just_ECS <- filter(runlist, ssp == MAIN_SCENARIO)
 tibble(lognorm = ecs_vals_lognorm, transformed = just_ECS$ECS) %>% 
   pivot_longer(everything()) %>% 
   ggplot(aes(value, fill = name)) + geom_density(alpha = 0.5) +

--- a/trackingC_setup.Rmd
+++ b/trackingC_setup.Rmd
@@ -258,7 +258,7 @@ run_hector <- function(pdata, c, sce) {
   }
   message("  ")
   # Set a tracking date, reset and run core
-  setvar(c, NA, TRACKING_DATE(), 1950, NA)
+  setvar(c, NA, TRACKING_DATE(), 1750, NA)
   reset(c)
   run(c)
   # Access and save tracking data, model outputs

--- a/trackingC_setup.Rmd
+++ b/trackingC_setup.Rmd
@@ -238,14 +238,19 @@ jv %>%
   filter(ECS > 0) %>% 
   sample_n(N_RUNS_MAIN) %>%
   bind_cols(runlist_main, .) ->
-  runlist
+  runlist_main
 
 # Down sort to the first 100 runs and bind to the scenario runlist
-small_runlist <- runlist %>%
+small_runlist <- runlist_main %>%
   filter(run_number %in% 1:100) %>%
   select(run_number, ECS, DIFFUSIVITY)
 
 runlist_scenario <- left_join(runlist_scenario, small_runlist, by = "run_number")
+
+# Combine runlists
+runlist <- runlist_scenario %>%
+  filter(scenario != "SSP245") %>%
+  bind_rows(runlist_main)
 
 # Visualize the final joint distribution of ECS and DIFFUSIVITY
 p <- ggplot(runlist, aes(ECS, DIFFUSIVITY)) + 
@@ -259,7 +264,8 @@ ggExtra::ggMarginal(p, type = "histogram", alpha = 0.2)
 ``` {r log-dist, fig.cap = " Comparing the original, random, lognormal distribution for ECS with the final transformed version, the exponential of the log of ECS."}
 
 # Visualize proper lognormal versus transformed distributions for ECS
-tibble(lognorm = ecs_vals_lognorm, transformed = runlist$ECS) %>% 
+just_ECS <- filter(runlist, scenario == "SSP245")
+tibble(lognorm = ecs_vals_lognorm, transformed = just_ECS$ECS) %>% 
   pivot_longer(everything()) %>% 
   ggplot(aes(value, fill = name)) + geom_density(alpha = 0.5) +
   ggtitle("Comparison of (proper) lognormal with transformed distribution for ECS")

--- a/trackingC_setup.Rmd
+++ b/trackingC_setup.Rmd
@@ -112,7 +112,7 @@ set.seed(10)
 
 Currently, we are looking at seven Hector parameters: `BETA(), Q10_RH(), ECS(),
 NPP_FLUX0(), AERO_SCALE(), DIFFUSIVITY(), and a LUC emissions scalar`. 
-We created a runlist with `r SSP_runs[[MAIN_SCENARIO]]` random
+We created a runlist with `r # SSP_runs[[MAIN_SCENARIO]]` random
 draws in a normal (or lognormal, where applicable) distribution.
 
 ECS (equilibrium climate sensitivity) and ocean heat diffusivity are 
@@ -326,7 +326,7 @@ tm <- difftime(Sys.time(), start_time, units = "secs") %>% round(1)
 errors <- unlist(errors)
 ```
 
-Doing `r nrow(runlist)` runs took `r tm` seconds or `r tm/((N_RUNS_SCE * 2) + N_RUNS_MAIN)` s/job.
+Doing `r nrow(runlist)` runs took `r tm` seconds or `r tm/(sum(SSP_runs[1:5]))` s/job.
 
 `r length(errors)` runs had errors.
 

--- a/trackingC_setup.Rmd
+++ b/trackingC_setup.Rmd
@@ -188,12 +188,12 @@ runlist_scenario <- left_join(runlist_sce, param_sce, by = "run_number")
 
 # Next, create a dataframe for just the main scenario, SSP
 # This will include the first 100 runs from the scenario runlist, above
-N_RUNS_MAIN <- 1000
+N_RUNS_MAIN <- 200
 runlist_ma <- tibble(
   # Creates a sequence from one above the number of scenario runs to the
   # number of main runs, eg 101 to 1000
   run_number = (1 + N_RUNS_SCE:(N_RUNS_MAIN-1)),
-  ssp = rep("SSP245", times = length(run_number))
+  ssp = rep("ssp245", times = length(run_number))
 )
 
 # Create parameter dataset and combine with run number and scenario
@@ -203,7 +203,7 @@ runlist_mai <- left_join(runlist_ma, param_main, by = "run_number")
 
 # Now, combine the first 100 runs from runlist_scenario to get a final, main scenario runlist
 runlist_main <- runlist_scenario %>%
-  filter(ssp == "SSP245") %>%
+  filter(ssp == "ssp245") %>%
   bind_rows(runlist_mai)
 
 ```
@@ -251,7 +251,7 @@ runlist_scenario <- left_join(runlist_scenario, small_runlist, by = "run_number"
 
 # Combine runlists
 runlist <- runlist_scenario %>%
-  filter(ssp != "SSP245") %>%
+  filter(ssp != "ssp245") %>%
   bind_rows(runlist_main)
 
 # Visualize the final joint distribution of ECS and DIFFUSIVITY
@@ -266,7 +266,7 @@ ggExtra::ggMarginal(p, type = "histogram", alpha = 0.2)
 ``` {r log-dist, fig.cap = " Comparing the original, random, lognormal distribution for ECS with the final transformed version, the exponential of the log of ECS."}
 
 # Visualize proper lognormal versus transformed distributions for ECS
-just_ECS <- filter(runlist, ssp == "SSP245")
+just_ECS <- filter(runlist, ssp == "ssp245")
 tibble(lognorm = ecs_vals_lognorm, transformed = just_ECS$ECS) %>% 
   pivot_longer(everything()) %>% 
   ggplot(aes(value, fill = name)) + geom_density(alpha = 0.5) +
@@ -329,7 +329,7 @@ for(s in names(SSP_files)) {
   core <- newcore(SSP_files[s])
   # Extract and LUC emissions data for later multiplication by LUC_SCALE
   run(core)
-  luc <- fetchvars(core, core$strtdate:core$enddate, LUC_EMISSIONS())
+  # luc <- fetchvars(core, core$strtdate:core$enddate, LUC_EMISSIONS())
   for(row in seq_len(nrow(s_runlist))) {
     message(row, "/", nrow(s_runlist))
     outp <- try(run_hector(s_runlist[row,][-c(1,2)], core))
@@ -376,10 +376,12 @@ model_output <- bind_rows(results, .id = "run_number") %>% as_tibble()
 # Can left join with runlist to get param values
 # Make sure data is same class
 trk_output$run_number <- as.integer(trk_output$run_number)
-trk_output <- left_join(trk_output, runlist, by = "run_number")
+trk_output <- left_join(trk_output, runlist, by = "run_number") %>%
+  arrange(ssp, run_number)
 
 model_output$run_number <- as.integer(model_output$run_number)
-model_output <- left_join(model_output, runlist, by = "run_number")
+model_output <- left_join(model_output, runlist, by = "run_number") %>%
+  arrange(ssp, run_number)
 
 ```
 

--- a/trackingC_setup.Rmd
+++ b/trackingC_setup.Rmd
@@ -176,7 +176,7 @@ run <- list()
 for(s in names(SSP_files)){
  run[[s]] <- data.frame(
    run_number = 1:N_RUNS_SCE,
-   scenario = rep(s, times = N_RUNS_SCE)
+   ssp = rep(s, times = N_RUNS_SCE)
  )}
 runlist_sce <- bind_rows(run)
 
@@ -192,7 +192,7 @@ runlist_scenario <- left_join(runlist_sce, param_sce, by = "run_number")
 N_RUNS_MAIN <- 1000
 runlist_ma <- tibble(
   run_number = (1 + N_RUNS_SCE:(N_RUNS_MAIN-1)),
-  scenario = rep("SSP245", times = length(run_number))
+  ssp = rep("SSP245", times = length(run_number))
 )
 
 # Create parameter dataset and combine with run number and scenario
@@ -201,7 +201,7 @@ runlist_mai <- left_join(runlist_ma, param_main, by = "run_number")
 
 # Now, combine the first 100 runs from runlist_scenario to get a final, main scenario runlist
 runlist_main <- runlist_scenario %>%
-  filter(scenario == "SSP245") %>%
+  filter(ssp == "SSP245") %>%
   bind_rows(runlist_mai)
 
 ```
@@ -249,7 +249,7 @@ runlist_scenario <- left_join(runlist_scenario, small_runlist, by = "run_number"
 
 # Combine runlists
 runlist <- runlist_scenario %>%
-  filter(scenario != "SSP245") %>%
+  filter(ssp != "SSP245") %>%
   bind_rows(runlist_main)
 
 # Visualize the final joint distribution of ECS and DIFFUSIVITY
@@ -264,7 +264,7 @@ ggExtra::ggMarginal(p, type = "histogram", alpha = 0.2)
 ``` {r log-dist, fig.cap = " Comparing the original, random, lognormal distribution for ECS with the final transformed version, the exponential of the log of ECS."}
 
 # Visualize proper lognormal versus transformed distributions for ECS
-just_ECS <- filter(runlist, scenario == "SSP245")
+just_ECS <- filter(runlist, ssp == "SSP245")
 tibble(lognorm = ecs_vals_lognorm, transformed = just_ECS$ECS) %>% 
   pivot_longer(everything()) %>% 
   ggplot(aes(value, fill = name)) + geom_density(alpha = 0.5) +
@@ -321,16 +321,23 @@ errors <- list()
 
 # Record start time 
 start_time <- Sys.time()
-
-for(row in seq_len(nrow(runlist))) {
-  message(row, "/", nrow(runlist))
-  outp <- try(run_hector(runlist[row,][-1], core))
-  if(class(outp) == "try-error") { 
-    # if there is an error, record row numbers that error
-    errors[[row]] <- runlist$run_number[[row]]
-  } else {
-    out[[runlist$run_number[row]]] <- outp
-  }}  
+for(s in names(SSP_files)) {
+  # Filter runlist by scenario
+  s_runlist <- runlist %>% filter(ssp == s)
+  core <- newcore(SSP_files[s])
+  # Extract and LUC emissions data for later multiplication by LUC_SCALAR
+  run(core)
+  luc <- fetchvars(core, core$strtdate:core$enddate, LUC_EMISSIONS())
+  for(row in seq_len(nrow(s_runlist))) {
+    message(row, "/", nrow(s_runlist))
+    outp <- try(run_hector(s_runlist[row,][-c(1,2)], core))
+    if(class(outp) == "try-error") { 
+      # if there is an error, record row numbers that error
+      errors[[row]] <- s_runlist$run_number[[row]]
+    } else {
+      out[[s_runlist$run_number[row]]] <- outp
+    }}  
+}
 
 # Compute difference in time between start and after loop is run
 tm <- difftime(Sys.time(), start_time, units = "secs") %>% round(1)

--- a/trackingC_setup.Rmd
+++ b/trackingC_setup.Rmd
@@ -188,15 +188,17 @@ runlist_scenario <- left_join(runlist_sce, param_sce, by = "run_number")
 
 # Next, create a dataframe for just the main scenario, SSP
 # This will include the first 100 runs from the scenario runlist, above
-# So, if we want 1,000 runs, we need to pass in one less
 N_RUNS_MAIN <- 1000
 runlist_ma <- tibble(
+  # Creates a sequence from one above the number of scenario runs to the
+  # number of main runs, eg 101 to 1000
   run_number = (1 + N_RUNS_SCE:(N_RUNS_MAIN-1)),
   ssp = rep("SSP245", times = length(run_number))
 )
 
 # Create parameter dataset and combine with run number and scenario
 param_main <- params(nrow(runlist_ma))
+param_main$run_number <- param_main$run_number + N_RUNS_SCE
 runlist_mai <- left_join(runlist_ma, param_main, by = "run_number")
 
 # Now, combine the first 100 runs from runlist_scenario to get a final, main scenario runlist
@@ -325,7 +327,7 @@ for(s in names(SSP_files)) {
   # Filter runlist by scenario
   s_runlist <- runlist %>% filter(ssp == s)
   core <- newcore(SSP_files[s])
-  # Extract and LUC emissions data for later multiplication by LUC_SCALAR
+  # Extract and LUC emissions data for later multiplication by LUC_SCALE
   run(core)
   luc <- fetchvars(core, core$strtdate:core$enddate, LUC_EMISSIONS())
   for(row in seq_len(nrow(s_runlist))) {
@@ -346,7 +348,7 @@ tm <- difftime(Sys.time(), start_time, units = "secs") %>% round(1)
 errors <- unlist(errors)
 ```
 
-Doing `r N_RUNS` runs took `r tm` seconds or `r tm/N_RUNS` s/job.
+Doing `r ((N_RUNS_SCE * 2) + N_RUNS_MAIN)` runs took `r tm` seconds or `r tm/((N_RUNS_SCE * 2) + N_RUNS_MAIN)` s/job.
 
 `r length(errors)` runs had errors.
 

--- a/trackingC_setup.Rmd
+++ b/trackingC_setup.Rmd
@@ -112,7 +112,7 @@ set.seed(10)
 
 Currently, we are looking at seven Hector parameters: `BETA(), Q10_RH(), ECS(),
 NPP_FLUX0(), AERO_SCALE(), DIFFUSIVITY(), and a LUC emissions scalar`. 
-We created a runlist with `r N_RUNS` random
+We created a runlist with `r SSP_runs[[MAIN_SCENARIO]]` random
 draws in a normal (or lognormal, where applicable) distribution.
 
 ECS (equilibrium climate sensitivity) and ocean heat diffusivity are 
@@ -183,7 +183,6 @@ runlist <- left_join(runlist, param_sce, by = "run_number")
 
 ``` {r joint-params, fig.cap = " The final joint distribution of ECS and diffusivity. The individual parameter distributions are shown on the x and y axes."}
 # Joint PDF for ECS and diffusivity
-# Use N_RUNS_MAIN and down sort later
 # Sherwood et al (2020)
 ecs_vals_lognorm <- rlnorm(nrow(runlist), 
                            lognorm(3.25, 0.65)[1], 
@@ -327,7 +326,7 @@ tm <- difftime(Sys.time(), start_time, units = "secs") %>% round(1)
 errors <- unlist(errors)
 ```
 
-Doing `r ((N_RUNS_SCE * 2) + N_RUNS_MAIN)` runs took `r tm` seconds or `r tm/((N_RUNS_SCE * 2) + N_RUNS_MAIN)` s/job.
+Doing `r nrow(runlist)` runs took `r tm` seconds or `r tm/((N_RUNS_SCE * 2) + N_RUNS_MAIN)` s/job.
 
 `r length(errors)` runs had errors.
 

--- a/trackingC_setup.Rmd
+++ b/trackingC_setup.Rmd
@@ -241,7 +241,7 @@ jv %>%
 
 # Down sort to the first 100 runs and bind to the scenario runlist
 small_runlist <- runlist_main %>%
-  filter(run_number %in% 1:100) %>%
+  filter(run_number %in% 1:N_RUNS_SCE) %>%
   select(run_number, ECS, DIFFUSIVITY)
 
 runlist_scenario <- left_join(runlist_scenario, small_runlist, by = "run_number")


### PR DESCRIPTION
Hi @bpbond,

This initial code (work in progress!) reworks my existing scripts so that Hector can be run in multiple scenarios. This might not be the most efficient way to do this, but it works and does not majorly increase computation time.

There are quite a few little tweaks that I made to get this to work, but the major changes are as follows:
- There are now two run lists, `runlist_scenarios` and `runlist_main`. The first contains `N_RUNS_SCE` runs [I used 100 for now] for all specified scenarios, and the second contains `N_RUNS_MAIN` runs of _just_ the main scenario, defined in the `trackingC_common.R` file.
- The first 100 runs contain the same parameter distributions, so for example, run 1 has the same combination of parameter values across all scenarios. 
- The run loop is now a nested for loop. First, it loops over each scenario and initiates a new core. Then, it applies `run_hector()` as it did before, and shuts down the core at the end. 

I started to tackle redoing some figures. I was able to run the CMIP6 temperature comparison diagnostic and filter out bad runs by scenario. Which figures would be most useful to modify to include all the SSPs? I think definitely the airborne fraction and the destination fraction graphs, and the relative importance one. 

Comments and feedback appreciated, as always. Happy to go over the changes, too. Thanks!