### PR TITLE
Airborne fraction trend

### DIFF
--- a/trackingC.Rmd
+++ b/trackingC.Rmd
@@ -579,9 +579,13 @@ af_trend <-  trend %>%
             broom::tidy(mod)) %>%
   filter(term == "year") %>%
   mutate(decade = estimate * 10,
-         error_decade = std.error * 10) %>%
-  arrange(def)
+         error = std.error * 10)
 
+clean_trend <- af_trend %>%
+  arrange(def) %>%
+  select(ssp, def, decade, error, p.value) %>%
+  rename("computation" = def, 
+         "trend" = decade)
 
 ```
 

--- a/trackingC.Rmd
+++ b/trackingC.Rmd
@@ -112,7 +112,7 @@ trk_output_filtered <- trk_output %>%
   filter(fraction_fail < 0.5)
 
 # Create facet labels
-ssp_labels <- c("SSP119", "SSP126", "SSP245", "SSP370", "SSP434", "SSP460", "SSP534-over", "SSP585")
+ssp_labels <- c("SSP126", "SSP245", "SSP370", "SSP460", "SSP585")
 names(ssp_labels) <- c(names(SSP_runs))
 
 # Plot temperature spreads for the filtered runs
@@ -567,6 +567,24 @@ ggplot(plot_data, aes(x = year, fill = def)) +
 
 ```
 
+``` {r af-trend, eval=FALSE}
+trend <- plot_data %>%
+  filter(year %in% 1960:2020)
+
+af_trend <-  trend %>%
+  group_by(ssp, def) %>%
+  do(mod = lm(med ~ year, data = .)) %>%
+  summarize(ssp = ssp,
+            def = def,
+            broom::tidy(mod)) %>%
+  filter(term == "year") %>%
+  mutate(decade = estimate * 10,
+         error_decade = std.error * 10) %>%
+  arrange(def)
+
+
+```
+
 
 # Supplementary figures
 
@@ -686,7 +704,7 @@ ggpairs(ffi_atm_2100,
 
 # Airborne fraction window size
 
-```{r s-af-window, fig.cap = " Parameter correlations and distributions (diagonal), with color indicating how much of the atmosphere is composed of anthropogenic CO2 in the year 2100."}
+```{r s-af-window, fig.cap = " Airborne fraction mathematically computed over varying time window sizes."}
 # Plot airborne fraction window size plot
 af_results %>% 
   group_by(year, ssp, window_size) %>% 

--- a/trackingC_common.R
+++ b/trackingC_common.R
@@ -22,14 +22,14 @@ units_vector <- c("BETA" = "(unitless)",
 scalar_vector <- "LUC_SCALE"
 
 # Number of runs for each SSP scenario
-SSP_runs <- c("ssp119" = 300,
-              "ssp126" = 300,
+SSP_runs <- c(#"ssp119" = 100,
+              "ssp126" = 500,
               "ssp245" = 500,
-              "ssp370" = 300,
-              "ssp434" = 300,
-              "ssp460" = 300,
-              "ssp534-over" = 300,
-              "ssp585" = 300)
+              "ssp370" = 500,
+              #"ssp434" = 100,
+              "ssp460" = 500,
+              #"ssp534-over" = 100,
+              "ssp585" = 500)
 
 # We use GitHub Actions to make sure this RMarkdown knits successfully
 # But if running there, only do a small number of Hector simulations


### PR DESCRIPTION
Following the discussion in #37, here is code that calculates the airborne fraction decadal trend from 1960-2020 by scenario and computation method. 

Interesting to note that the mathematical definition returns trend numbers very similar to those in van Marle et al., although with a much lower error, but the carbon tracking method's trends are much smaller values.
